### PR TITLE
feat(portfolio-view): portfolio view screen (closes #1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,25 @@
 import { useState } from 'react'
+import { PortfolioPage } from './features/portfolio-view/ui/PortfolioPage'
 import { AllocationPage } from './features/target-allocation/ui/AllocationPage'
 import { OptimizationDashboard } from './features/portfolio-optimization/ui/OptimizationDashboard'
 import { DiversificationDashboard } from './features/diversification/ui/DiversificationDashboard'
 
-type Page = 'allocation' | 'diversification' | 'optimization'
+type Page = 'portfolio' | 'allocation' | 'diversification' | 'optimization'
 
 export function App() {
-  const [page, setPage] = useState<Page>('allocation')
+  const [page, setPage] = useState<Page>('portfolio')
 
   return (
     <div className="app">
       <header className="app-header">
         <h1>Мои Инвестиции</h1>
         <nav className="app-nav">
+          <button
+            className={`nav-btn ${page === 'portfolio' ? 'active' : ''}`}
+            onClick={() => setPage('portfolio')}
+          >
+            Портфель
+          </button>
           <button
             className={`nav-btn ${page === 'allocation' ? 'active' : ''}`}
             onClick={() => setPage('allocation')}
@@ -34,6 +41,7 @@ export function App() {
         </nav>
       </header>
       <main className="app-main">
+        {page === 'portfolio' && <PortfolioPage />}
         {page === 'allocation' && <AllocationPage />}
         {page === 'diversification' && (
           <DiversificationDashboard report={null} onAnalyze={() => {}} />

--- a/src/features/portfolio-view/domain/__tests__/formatters.test.ts
+++ b/src/features/portfolio-view/domain/__tests__/formatters.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { formatRub, formatPercent, gainClass, assetClassLabel, brokerLabel, accountTypeLabel } from '../formatters'
+
+describe('formatRub', () => {
+  it('formats positive values with RUB symbol', () => {
+    const result = formatRub(29550)
+    expect(result).toContain('29')
+    expect(result).toContain('550')
+  })
+
+  it('formats zero', () => {
+    const result = formatRub(0)
+    expect(result).toContain('0')
+  })
+
+  it('formats negative values', () => {
+    const result = formatRub(-4000)
+    expect(result).toContain('4')
+    expect(result).toContain('000')
+  })
+})
+
+describe('formatPercent', () => {
+  it('adds plus sign for positive values', () => {
+    expect(formatPercent(12.5)).toBe('+12.50%')
+  })
+
+  it('shows negative sign for negative values', () => {
+    expect(formatPercent(-3.14)).toBe('-3.14%')
+  })
+
+  it('shows zero without sign', () => {
+    expect(formatPercent(0)).toBe('0.00%')
+  })
+})
+
+describe('gainClass', () => {
+  it('returns gain-positive for positive', () => {
+    expect(gainClass(100)).toBe('gain-positive')
+  })
+
+  it('returns gain-negative for negative', () => {
+    expect(gainClass(-50)).toBe('gain-negative')
+  })
+
+  it('returns gain-neutral for zero', () => {
+    expect(gainClass(0)).toBe('gain-neutral')
+  })
+})
+
+describe('assetClassLabel', () => {
+  it('returns Russian labels for all asset classes', () => {
+    expect(assetClassLabel('stock')).toBe('Акции')
+    expect(assetClassLabel('bond')).toBe('Облигации')
+    expect(assetClassLabel('etf')).toBe('ETF')
+    expect(assetClassLabel('currency')).toBe('Валюта')
+    expect(assetClassLabel('other')).toBe('Прочее')
+  })
+})
+
+describe('brokerLabel', () => {
+  it('returns display names for all brokers', () => {
+    expect(brokerLabel('sberbank')).toBe('Сбербанк Инвестиции')
+    expect(brokerLabel('alfa')).toBe('Альфа-Инвестиции')
+    expect(brokerLabel('tbank')).toBe('Т-Инвестиции')
+    expect(brokerLabel('vtb')).toBe('ВТБ Мои Инвестиции')
+  })
+})
+
+describe('accountTypeLabel', () => {
+  it('returns Russian labels for account types', () => {
+    expect(accountTypeLabel('standard')).toBe('Брокерский счёт')
+    expect(accountTypeLabel('iis')).toBe('ИИС')
+    expect(accountTypeLabel('trust_management')).toBe('ПДС (доверительное управление)')
+    expect(accountTypeLabel('auto_managed')).toBe('Инвест-копилка')
+  })
+})

--- a/src/features/portfolio-view/domain/formatters.ts
+++ b/src/features/portfolio-view/domain/formatters.ts
@@ -1,0 +1,60 @@
+import type { AssetClass, BrokerName, AccountType } from './models'
+
+export function formatRub(value: number): string {
+  return value.toLocaleString('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+}
+
+export function formatPercent(value: number): string {
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${value.toFixed(2)}%`
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ru-RU', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+export function gainClass(value: number): string {
+  if (value > 0) return 'gain-positive'
+  if (value < 0) return 'gain-negative'
+  return 'gain-neutral'
+}
+
+export function assetClassLabel(assetClass: AssetClass): string {
+  const labels: Record<AssetClass, string> = {
+    stock: 'Акции',
+    bond: 'Облигации',
+    etf: 'ETF',
+    currency: 'Валюта',
+    other: 'Прочее',
+  }
+  return labels[assetClass]
+}
+
+export function brokerLabel(broker: BrokerName): string {
+  const labels: Record<BrokerName, string> = {
+    sberbank: 'Сбербанк Инвестиции',
+    alfa: 'Альфа-Инвестиции',
+    tbank: 'Т-Инвестиции',
+    vtb: 'ВТБ Мои Инвестиции',
+  }
+  return labels[broker]
+}
+
+export function accountTypeLabel(accountType: AccountType): string {
+  const labels: Record<AccountType, string> = {
+    standard: 'Брокерский счёт',
+    iis: 'ИИС',
+    trust_management: 'ПДС (доверительное управление)',
+    auto_managed: 'Инвест-копилка',
+  }
+  return labels[accountType]
+}

--- a/src/features/portfolio-view/domain/models.ts
+++ b/src/features/portfolio-view/domain/models.ts
@@ -1,0 +1,55 @@
+export type BrokerName = 'sberbank' | 'alfa' | 'tbank' | 'vtb'
+export type AccountType = 'standard' | 'iis' | 'trust_management' | 'auto_managed'
+export type AssetClass = 'stock' | 'bond' | 'etf' | 'currency' | 'other'
+export type AssetSubclass = 'common' | 'preferred' | 'ofz' | 'corporate' | 'municipal'
+
+export interface ViewPosition {
+  ticker: string
+  name: string
+  broker: BrokerName
+  accountType: AccountType
+  assetClass: AssetClass
+  assetSubclass?: AssetSubclass
+  sector: string
+  currency: 'RUB'
+  quantity: number
+  currentPrice: number
+  currentValue: number
+  costBasis: number
+  purchaseDate: string
+  dailyVolume: number
+  unrealizedGain: number
+  unrealizedGainPercent: number
+  portfolioWeight: number
+}
+
+export interface BrokerAccount {
+  broker: BrokerName
+  displayName: string
+  accountType: AccountType
+  positions: ViewPosition[]
+  totalValue: number
+  totalGain: number
+  positionCount: number
+}
+
+export interface AllocationBreakdown {
+  category: string
+  percent: number
+  value: number
+}
+
+export interface PortfolioMetrics {
+  totalValue: number
+  totalCostBasis: number
+  totalGain: number
+  totalGainPercent: number
+  positionCount: number
+  brokerCount: number
+  allocationByAssetClass: AllocationBreakdown[]
+  allocationBySector: AllocationBreakdown[]
+  topHoldings: ViewPosition[]
+}
+
+export type SortField = 'ticker' | 'name' | 'broker' | 'assetClass' | 'quantity' | 'currentPrice' | 'currentValue' | 'unrealizedGain' | 'portfolioWeight'
+export type SortDirection = 'asc' | 'desc'

--- a/src/features/portfolio-view/index.ts
+++ b/src/features/portfolio-view/index.ts
@@ -1,0 +1,2 @@
+export { PortfolioPage } from './ui/PortfolioPage'
+export type { ViewPosition, BrokerAccount, PortfolioMetrics, BrokerName, AllocationBreakdown } from './domain/models'

--- a/src/features/portfolio-view/services/__tests__/metrics-service.test.ts
+++ b/src/features/portfolio-view/services/__tests__/metrics-service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { computeMetrics } from '../metrics-service'
+import type { ViewPosition } from '../../domain/models'
+
+const MOCK: ViewPosition[] = [
+  {
+    ticker: 'SBER', name: 'Сбербанк', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', sector: 'Финансы', currency: 'RUB',
+    quantity: 100, currentPrice: 300, currentValue: 30000, costBasis: 25000,
+    purchaseDate: '2024-01-01', dailyVolume: 1000000,
+    unrealizedGain: 5000, unrealizedGainPercent: 20, portfolioWeight: 60,
+  },
+  {
+    ticker: 'OFZ26238', name: 'ОФЗ 26238', broker: 'alfa', accountType: 'iis',
+    assetClass: 'bond', assetSubclass: 'ofz', sector: 'Гос. облигации', currency: 'RUB',
+    quantity: 20, currentPrice: 1000, currentValue: 20000, costBasis: 19000,
+    purchaseDate: '2024-06-01', dailyVolume: 500000,
+    unrealizedGain: 1000, unrealizedGainPercent: 5.26, portfolioWeight: 40,
+  },
+]
+
+describe('computeMetrics', () => {
+  it('computes total value', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.totalValue).toBe(50000)
+  })
+
+  it('computes total cost basis', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.totalCostBasis).toBe(44000)
+  })
+
+  it('computes total gain and percent', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.totalGain).toBe(6000)
+    expect(m.totalGainPercent).toBeCloseTo(13.64, 1)
+  })
+
+  it('counts positions and brokers', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.positionCount).toBe(2)
+    expect(m.brokerCount).toBe(2)
+  })
+
+  it('computes allocation by asset class', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.allocationByAssetClass).toHaveLength(2)
+    const stocks = m.allocationByAssetClass.find(a => a.category === 'Акции')
+    expect(stocks).toBeDefined()
+    expect(stocks!.percent).toBeCloseTo(60, 0)
+  })
+
+  it('computes allocation by sector', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.allocationBySector).toHaveLength(2)
+  })
+
+  it('returns top holdings sorted by value', () => {
+    const m = computeMetrics(MOCK)
+    expect(m.topHoldings[0].ticker).toBe('SBER')
+  })
+
+  it('handles empty positions', () => {
+    const m = computeMetrics([])
+    expect(m.totalValue).toBe(0)
+    expect(m.totalGain).toBe(0)
+    expect(m.totalGainPercent).toBe(0)
+    expect(m.positionCount).toBe(0)
+    expect(m.brokerCount).toBe(0)
+  })
+})

--- a/src/features/portfolio-view/services/__tests__/portfolio-service.test.ts
+++ b/src/features/portfolio-view/services/__tests__/portfolio-service.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { getAllPositions, getPositionsByBroker, getBrokerAccounts } from '../portfolio-service'
+
+describe('getAllPositions', () => {
+  it('returns all mock positions', () => {
+    const positions = getAllPositions()
+    expect(positions.length).toBeGreaterThan(0)
+  })
+
+  it('computes portfolio weights that sum to ~100%', () => {
+    const positions = getAllPositions()
+    const totalWeight = positions.reduce((sum, p) => sum + p.portfolioWeight, 0)
+    expect(totalWeight).toBeCloseTo(100, 0)
+  })
+
+  it('every position has required fields', () => {
+    const positions = getAllPositions()
+    for (const p of positions) {
+      expect(p.ticker).toBeTruthy()
+      expect(p.name).toBeTruthy()
+      expect(p.broker).toBeTruthy()
+      expect(p.currency).toBe('RUB')
+      expect(p.currentValue).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('getPositionsByBroker', () => {
+  it('filters positions for sberbank', () => {
+    const positions = getPositionsByBroker('sberbank')
+    expect(positions.length).toBeGreaterThan(0)
+    for (const p of positions) {
+      expect(p.broker).toBe('sberbank')
+    }
+  })
+
+  it('filters positions for vtb', () => {
+    const positions = getPositionsByBroker('vtb')
+    expect(positions.length).toBeGreaterThan(0)
+    for (const p of positions) {
+      expect(p.broker).toBe('vtb')
+    }
+  })
+
+  it('recalculates weights within broker', () => {
+    const positions = getPositionsByBroker('sberbank')
+    const totalWeight = positions.reduce((sum, p) => sum + p.portfolioWeight, 0)
+    expect(totalWeight).toBeCloseTo(100, 0)
+  })
+})
+
+describe('getBrokerAccounts', () => {
+  it('returns accounts for all 4 brokers', () => {
+    const accounts = getBrokerAccounts()
+    const brokers = new Set(accounts.map(a => a.broker))
+    expect(brokers.size).toBe(4)
+    expect(brokers.has('sberbank')).toBe(true)
+    expect(brokers.has('alfa')).toBe(true)
+    expect(brokers.has('tbank')).toBe(true)
+    expect(brokers.has('vtb')).toBe(true)
+  })
+
+  it('each account has correct totals', () => {
+    const accounts = getBrokerAccounts()
+    for (const account of accounts) {
+      const expectedValue = account.positions.reduce((sum, p) => sum + p.currentValue, 0)
+      expect(account.totalValue).toBe(expectedValue)
+      expect(account.positionCount).toBe(account.positions.length)
+    }
+  })
+
+  it('separates accounts by type for VTB', () => {
+    const accounts = getBrokerAccounts()
+    const vtbAccounts = accounts.filter(a => a.broker === 'vtb')
+    expect(vtbAccounts.length).toBeGreaterThanOrEqual(2)
+    const types = vtbAccounts.map(a => a.accountType)
+    expect(types).toContain('auto_managed')
+    expect(types).toContain('trust_management')
+  })
+})

--- a/src/features/portfolio-view/services/metrics-service.ts
+++ b/src/features/portfolio-view/services/metrics-service.ts
@@ -1,0 +1,52 @@
+import type { ViewPosition, PortfolioMetrics, AllocationBreakdown } from '../domain/models'
+import { assetClassLabel } from '../domain/formatters'
+
+export function computeMetrics(positions: ViewPosition[]): PortfolioMetrics {
+  const totalValue = positions.reduce((sum, p) => sum + p.currentValue, 0)
+  const totalCostBasis = positions.reduce((sum, p) => sum + p.costBasis, 0)
+  const totalGain = totalValue - totalCostBasis
+  const totalGainPercent = totalCostBasis > 0 ? ((totalGain / totalCostBasis) * 100) : 0
+  const brokerCount = new Set(positions.map(p => p.broker)).size
+
+  const allocationByAssetClass = computeAllocation(positions, 'assetClass', totalValue)
+  const allocationBySector = computeAllocation(positions, 'sector', totalValue)
+
+  const sorted = [...positions].sort((a, b) => b.currentValue - a.currentValue)
+  const topHoldings = sorted.slice(0, 5)
+
+  return {
+    totalValue,
+    totalCostBasis,
+    totalGain,
+    totalGainPercent,
+    positionCount: positions.length,
+    brokerCount,
+    allocationByAssetClass,
+    allocationBySector,
+    topHoldings,
+  }
+}
+
+function computeAllocation(
+  positions: ViewPosition[],
+  dimension: 'assetClass' | 'sector',
+  totalValue: number,
+): AllocationBreakdown[] {
+  const groups = new Map<string, number>()
+
+  for (const p of positions) {
+    const key = dimension === 'assetClass' ? assetClassLabel(p.assetClass) : p.sector
+    groups.set(key, (groups.get(key) ?? 0) + p.currentValue)
+  }
+
+  const result: AllocationBreakdown[] = []
+  for (const [category, value] of groups) {
+    result.push({
+      category,
+      percent: totalValue > 0 ? (value / totalValue) * 100 : 0,
+      value,
+    })
+  }
+
+  return result.sort((a, b) => b.value - a.value)
+}

--- a/src/features/portfolio-view/services/portfolio-service.ts
+++ b/src/features/portfolio-view/services/portfolio-service.ts
@@ -1,0 +1,166 @@
+import type { ViewPosition, BrokerAccount, BrokerName } from '../domain/models'
+
+const MOCK_POSITIONS: ViewPosition[] = [
+  // Сбербанк — акции
+  {
+    ticker: 'SBER', name: 'Сбербанк', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Финансы', currency: 'RUB',
+    quantity: 100, currentPrice: 295.5, currentValue: 29550, costBasis: 24000,
+    purchaseDate: '2024-03-15', dailyVolume: 45000000,
+    unrealizedGain: 5550, unrealizedGainPercent: 23.13, portfolioWeight: 0,
+  },
+  {
+    ticker: 'SBERP', name: 'Сбербанк (прив.)', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'preferred', sector: 'Финансы', currency: 'RUB',
+    quantity: 50, currentPrice: 280.0, currentValue: 14000, costBasis: 12500,
+    purchaseDate: '2024-05-10', dailyVolume: 8000000,
+    unrealizedGain: 1500, unrealizedGainPercent: 12.0, portfolioWeight: 0,
+  },
+  {
+    ticker: 'LKOH', name: 'Лукойл', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Нефть и газ', currency: 'RUB',
+    quantity: 5, currentPrice: 7200, currentValue: 36000, costBasis: 32000,
+    purchaseDate: '2024-01-20', dailyVolume: 3500000,
+    unrealizedGain: 4000, unrealizedGainPercent: 12.5, portfolioWeight: 0,
+  },
+  // Альфа — облигации
+  {
+    ticker: 'SU26238', name: 'ОФЗ 26238', broker: 'alfa', accountType: 'iis',
+    assetClass: 'bond', assetSubclass: 'ofz', sector: 'Гос. облигации', currency: 'RUB',
+    quantity: 50, currentPrice: 620, currentValue: 31000, costBasis: 30000,
+    purchaseDate: '2024-06-01', dailyVolume: 500000,
+    unrealizedGain: 1000, unrealizedGainPercent: 3.33, portfolioWeight: 0,
+  },
+  {
+    ticker: 'RU000A106Y', name: 'Газпром Капитал', broker: 'alfa', accountType: 'iis',
+    assetClass: 'bond', assetSubclass: 'corporate', sector: 'Нефть и газ', currency: 'RUB',
+    quantity: 30, currentPrice: 980, currentValue: 29400, costBasis: 28500,
+    purchaseDate: '2024-04-15', dailyVolume: 200000,
+    unrealizedGain: 900, unrealizedGainPercent: 3.16, portfolioWeight: 0,
+  },
+  // Т-Банк — ETF и акции
+  {
+    ticker: 'TMOS', name: 'Тинькофф iMOEX', broker: 'tbank', accountType: 'standard',
+    assetClass: 'etf', sector: 'Широкий рынок', currency: 'RUB',
+    quantity: 500, currentPrice: 6.8, currentValue: 3400, costBasis: 3000,
+    purchaseDate: '2024-07-10', dailyVolume: 15000000,
+    unrealizedGain: 400, unrealizedGainPercent: 13.33, portfolioWeight: 0,
+  },
+  {
+    ticker: 'GAZP', name: 'Газпром', broker: 'tbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Нефть и газ', currency: 'RUB',
+    quantity: 200, currentPrice: 155, currentValue: 31000, costBasis: 35000,
+    purchaseDate: '2024-02-20', dailyVolume: 30000000,
+    unrealizedGain: -4000, unrealizedGainPercent: -11.43, portfolioWeight: 0,
+  },
+  {
+    ticker: 'YNDX', name: 'Яндекс', broker: 'tbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Технологии', currency: 'RUB',
+    quantity: 10, currentPrice: 3950, currentValue: 39500, costBasis: 30000,
+    purchaseDate: '2024-08-01', dailyVolume: 2500000,
+    unrealizedGain: 9500, unrealizedGainPercent: 31.67, portfolioWeight: 0,
+  },
+  {
+    ticker: 'MGNT', name: 'Магнит', broker: 'tbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Потребительский', currency: 'RUB',
+    quantity: 3, currentPrice: 5200, currentValue: 15600, costBasis: 14400,
+    purchaseDate: '2024-09-05', dailyVolume: 500000,
+    unrealizedGain: 1200, unrealizedGainPercent: 8.33, portfolioWeight: 0,
+  },
+  // ВТБ — спец. счета
+  {
+    ticker: 'TBRU', name: 'Тинькофф Облигации', broker: 'vtb', accountType: 'auto_managed',
+    assetClass: 'etf', sector: 'Облигации', currency: 'RUB',
+    quantity: 1000, currentPrice: 5.5, currentValue: 5500, costBasis: 5000,
+    purchaseDate: '2024-10-01', dailyVolume: 5000000,
+    unrealizedGain: 500, unrealizedGainPercent: 10.0, portfolioWeight: 0,
+  },
+  {
+    ticker: 'VTBM', name: 'ВТБ Ликвидность', broker: 'vtb', accountType: 'trust_management',
+    assetClass: 'etf', sector: 'Денежный рынок', currency: 'RUB',
+    quantity: 2000, currentPrice: 1.08, currentValue: 2160, costBasis: 2000,
+    purchaseDate: '2024-11-10', dailyVolume: 30000000,
+    unrealizedGain: 160, unrealizedGainPercent: 8.0, portfolioWeight: 0,
+  },
+  {
+    ticker: 'GMKN', name: 'Норильский Никель', broker: 'vtb', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Металлургия', currency: 'RUB',
+    quantity: 2, currentPrice: 13800, currentValue: 27600, costBasis: 25000,
+    purchaseDate: '2024-04-20', dailyVolume: 1200000,
+    unrealizedGain: 2600, unrealizedGainPercent: 10.4, portfolioWeight: 0,
+  },
+  {
+    ticker: 'ROSN', name: 'Роснефть', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Нефть и газ', currency: 'RUB',
+    quantity: 50, currentPrice: 580, currentValue: 29000, costBasis: 26000,
+    purchaseDate: '2024-03-01', dailyVolume: 5000000,
+    unrealizedGain: 3000, unrealizedGainPercent: 11.54, portfolioWeight: 0,
+  },
+  {
+    ticker: 'MOEX', name: 'Московская биржа', broker: 'alfa', accountType: 'iis',
+    assetClass: 'stock', assetSubclass: 'common', sector: 'Финансы', currency: 'RUB',
+    quantity: 100, currentPrice: 230, currentValue: 23000, costBasis: 20000,
+    purchaseDate: '2024-07-15', dailyVolume: 3000000,
+    unrealizedGain: 3000, unrealizedGainPercent: 15.0, portfolioWeight: 0,
+  },
+  {
+    ticker: 'SU26240', name: 'ОФЗ 26240', broker: 'vtb', accountType: 'standard',
+    assetClass: 'bond', assetSubclass: 'ofz', sector: 'Гос. облигации', currency: 'RUB',
+    quantity: 20, currentPrice: 710, currentValue: 14200, costBasis: 13800,
+    purchaseDate: '2024-08-20', dailyVolume: 300000,
+    unrealizedGain: 400, unrealizedGainPercent: 2.9, portfolioWeight: 0,
+  },
+]
+
+function computeWeights(positions: ViewPosition[]): ViewPosition[] {
+  const total = positions.reduce((sum, p) => sum + p.currentValue, 0)
+  if (total === 0) return positions
+  return positions.map(p => ({
+    ...p,
+    portfolioWeight: (p.currentValue / total) * 100,
+  }))
+}
+
+export function getAllPositions(): ViewPosition[] {
+  return computeWeights(MOCK_POSITIONS)
+}
+
+export function getPositionsByBroker(broker: BrokerName): ViewPosition[] {
+  const filtered = MOCK_POSITIONS.filter(p => p.broker === broker)
+  return computeWeights(filtered)
+}
+
+export function getBrokerAccounts(): BrokerAccount[] {
+  const brokers: BrokerName[] = ['sberbank', 'alfa', 'tbank', 'vtb']
+  const displayNames: Record<BrokerName, string> = {
+    sberbank: 'Сбербанк Инвестиции',
+    alfa: 'Альфа-Инвестиции',
+    tbank: 'Т-Инвестиции',
+    vtb: 'ВТБ Мои Инвестиции',
+  }
+
+  const accounts: BrokerAccount[] = []
+  for (const broker of brokers) {
+    const positions = MOCK_POSITIONS.filter(p => p.broker === broker)
+    if (positions.length === 0) continue
+
+    const accountTypes = [...new Set(positions.map(p => p.accountType))]
+    for (const accountType of accountTypes) {
+      const acctPositions = positions.filter(p => p.accountType === accountType)
+      const totalValue = acctPositions.reduce((sum, p) => sum + p.currentValue, 0)
+      const totalGain = acctPositions.reduce((sum, p) => sum + p.unrealizedGain, 0)
+
+      accounts.push({
+        broker,
+        displayName: displayNames[broker],
+        accountType,
+        positions: acctPositions,
+        totalValue,
+        totalGain,
+        positionCount: acctPositions.length,
+      })
+    }
+  }
+
+  return accounts
+}

--- a/src/features/portfolio-view/ui/AllocationChart.tsx
+++ b/src/features/portfolio-view/ui/AllocationChart.tsx
@@ -1,0 +1,52 @@
+import type { AllocationBreakdown } from '../domain/models'
+import { formatRub } from '../domain/formatters'
+
+interface AllocationChartProps {
+  data: AllocationBreakdown[]
+  title: string
+}
+
+const COLORS = [
+  '#1976d2', '#2e7d32', '#e65100', '#7b1fa2',
+  '#c62828', '#00838f', '#f9a825', '#4e342e',
+  '#37474f', '#ad1457',
+]
+
+export function AllocationChart({ data, title }: AllocationChartProps) {
+  if (data.length === 0) return null
+
+  return (
+    <div className="allocation-section">
+      <h3>{title}</h3>
+      <div className="allocation-bar">
+        {data.map((item, i) => (
+          <div
+            key={item.category}
+            className="allocation-segment"
+            style={{
+              width: `${item.percent}%`,
+              backgroundColor: COLORS[i % COLORS.length],
+            }}
+            title={`${item.category}: ${item.percent.toFixed(1)}%`}
+          >
+            {item.percent >= 8 ? `${item.percent.toFixed(0)}%` : ''}
+          </div>
+        ))}
+      </div>
+      <div className="allocation-legend">
+        {data.map((item, i) => (
+          <div key={item.category} className="legend-item">
+            <div
+              className="legend-color"
+              style={{ backgroundColor: COLORS[i % COLORS.length] }}
+            />
+            <span>{item.category}</span>
+            <span className="legend-value">
+              {item.percent.toFixed(1)}% ({formatRub(item.value)})
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/portfolio-view/ui/BrokerBreakdown.tsx
+++ b/src/features/portfolio-view/ui/BrokerBreakdown.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import type { BrokerAccount } from '../domain/models'
+import { formatRub, formatPercent, gainClass, accountTypeLabel } from '../domain/formatters'
+
+interface BrokerBreakdownProps {
+  accounts: BrokerAccount[]
+}
+
+export function BrokerBreakdown({ accounts }: BrokerBreakdownProps) {
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  if (accounts.length === 0) {
+    return (
+      <div className="portfolio-empty">
+        <p>Нет подключённых брокеров.</p>
+      </div>
+    )
+  }
+
+  function toggleExpand(key: string) {
+    setExpanded(prev => prev === key ? null : key)
+  }
+
+  return (
+    <div>
+      {accounts.map(account => {
+        const key = `${account.broker}-${account.accountType}`
+        const isExpanded = expanded === key
+        const gainPercent = account.totalValue > 0
+          ? ((account.totalGain / (account.totalValue - account.totalGain)) * 100)
+          : 0
+
+        return (
+          <div className="broker-section" key={key}>
+            <div className="broker-card">
+              <div className="broker-card-header" onClick={() => toggleExpand(key)}>
+                <div className="broker-info">
+                  <h4>
+                    {account.displayName}
+                    <span className="account-type-badge">
+                      {accountTypeLabel(account.accountType)}
+                    </span>
+                  </h4>
+                  <span className="broker-meta">
+                    {account.positionCount} {positionWord(account.positionCount)}
+                  </span>
+                </div>
+                <div className="broker-stats">
+                  <div className="broker-value">{formatRub(account.totalValue)}</div>
+                  <div className={`broker-gain ${gainClass(account.totalGain)}`}>
+                    {formatRub(account.totalGain)} ({formatPercent(gainPercent)})
+                  </div>
+                </div>
+                <span className={`expand-icon ${isExpanded ? 'expanded' : ''}`}>▼</span>
+              </div>
+              {isExpanded && (
+                <div className="broker-positions">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Тикер</th>
+                        <th>Название</th>
+                        <th>Кол-во</th>
+                        <th>Стоимость</th>
+                        <th>Прибыль</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {account.positions.map(p => (
+                        <tr key={p.ticker}>
+                          <td><strong>{p.ticker}</strong></td>
+                          <td>{p.name}</td>
+                          <td>{p.quantity}</td>
+                          <td>{formatRub(p.currentValue)}</td>
+                          <td className={gainClass(p.unrealizedGain)}>
+                            {formatRub(p.unrealizedGain)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function positionWord(count: number): string {
+  if (count % 10 === 1 && count % 100 !== 11) return 'позиция'
+  if ([2, 3, 4].includes(count % 10) && ![12, 13, 14].includes(count % 100)) return 'позиции'
+  return 'позиций'
+}

--- a/src/features/portfolio-view/ui/HoldingsTable.tsx
+++ b/src/features/portfolio-view/ui/HoldingsTable.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import type { ViewPosition, SortField, SortDirection } from '../domain/models'
+import { formatRub, formatPercent, gainClass, assetClassLabel, brokerLabel } from '../domain/formatters'
+
+interface HoldingsTableProps {
+  positions: ViewPosition[]
+}
+
+export function HoldingsTable({ positions }: HoldingsTableProps) {
+  const [sortField, setSortField] = useState<SortField>('portfolioWeight')
+  const [sortDir, setSortDir] = useState<SortDirection>('desc')
+
+  function handleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  const sorted = [...positions].sort((a, b) => {
+    const aVal = a[sortField]
+    const bVal = b[sortField]
+    if (typeof aVal === 'string' && typeof bVal === 'string') {
+      return sortDir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+    }
+    const numA = Number(aVal)
+    const numB = Number(bVal)
+    return sortDir === 'asc' ? numA - numB : numB - numA
+  })
+
+  function sortIndicator(field: SortField) {
+    if (sortField !== field) return null
+    return <span className="sort-indicator">{sortDir === 'asc' ? '▲' : '▼'}</span>
+  }
+
+  if (positions.length === 0) {
+    return (
+      <div className="portfolio-empty">
+        <p>Нет позиций для отображения.</p>
+      </div>
+    )
+  }
+
+  return (
+    <table className="holdings-table">
+      <thead>
+        <tr>
+          <th onClick={() => handleSort('ticker')}>Тикер{sortIndicator('ticker')}</th>
+          <th onClick={() => handleSort('name')}>Название{sortIndicator('name')}</th>
+          <th onClick={() => handleSort('broker')}>Брокер{sortIndicator('broker')}</th>
+          <th onClick={() => handleSort('assetClass')}>Класс{sortIndicator('assetClass')}</th>
+          <th className="col-right" onClick={() => handleSort('quantity')}>Кол-во{sortIndicator('quantity')}</th>
+          <th className="col-right" onClick={() => handleSort('currentPrice')}>Цена{sortIndicator('currentPrice')}</th>
+          <th className="col-right" onClick={() => handleSort('currentValue')}>Стоимость{sortIndicator('currentValue')}</th>
+          <th className="col-right" onClick={() => handleSort('unrealizedGain')}>Прибыль{sortIndicator('unrealizedGain')}</th>
+          <th className="col-right" onClick={() => handleSort('portfolioWeight')}>% портфеля{sortIndicator('portfolioWeight')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map(p => (
+          <tr key={`${p.broker}-${p.ticker}`}>
+            <td><strong>{p.ticker}</strong></td>
+            <td>{p.name}</td>
+            <td>{brokerLabel(p.broker)}</td>
+            <td>{assetClassLabel(p.assetClass)}</td>
+            <td className="col-right">{p.quantity}</td>
+            <td className="col-right">{formatRub(p.currentPrice)}</td>
+            <td className="col-right">{formatRub(p.currentValue)}</td>
+            <td className={`col-right ${gainClass(p.unrealizedGain)}`}>
+              {formatRub(p.unrealizedGain)} ({formatPercent(p.unrealizedGainPercent)})
+            </td>
+            <td className="col-right">{p.portfolioWeight.toFixed(1)}%</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/features/portfolio-view/ui/PortfolioPage.css
+++ b/src/features/portfolio-view/ui/PortfolioPage.css
@@ -1,0 +1,275 @@
+.portfolio-page h2 {
+  margin-bottom: 1.5rem;
+}
+
+/* Summary cards */
+.portfolio-summary {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.summary-card {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  flex: 1;
+  min-width: 140px;
+}
+
+.summary-card-value {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.summary-card-label {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.gain-positive {
+  color: #2e7d32;
+}
+
+.gain-negative {
+  color: #f44336;
+}
+
+.gain-neutral {
+  color: #666;
+}
+
+/* Sub-navigation tabs */
+.portfolio-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e0e0e0;
+  margin-bottom: 1.5rem;
+}
+
+.portfolio-tab {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: #666;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.portfolio-tab.active {
+  color: #1976d2;
+  border-bottom-color: #1976d2;
+  font-weight: 600;
+}
+
+.portfolio-tab:hover {
+  color: #333;
+}
+
+/* Holdings table */
+.holdings-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.holdings-table th,
+.holdings-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.holdings-table th {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: #666;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.holdings-table th:hover {
+  color: #1976d2;
+}
+
+.holdings-table td {
+  font-size: 0.875rem;
+}
+
+.holdings-table .col-right {
+  text-align: right;
+}
+
+.sort-indicator {
+  margin-left: 0.25rem;
+  font-size: 0.7rem;
+}
+
+/* Broker breakdown */
+.broker-section {
+  margin-bottom: 1rem;
+}
+
+.broker-card {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.broker-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.broker-card-header:hover {
+  background: #fafafa;
+}
+
+.broker-info h4 {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+.broker-meta {
+  font-size: 0.8rem;
+  color: #666;
+}
+
+.account-type-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 10px;
+  background: #e3f2fd;
+  color: #1565c0;
+  margin-left: 0.5rem;
+}
+
+.broker-stats {
+  text-align: right;
+}
+
+.broker-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.broker-gain {
+  font-size: 0.8rem;
+}
+
+.broker-positions {
+  border-top: 1px solid #e0e0e0;
+  padding: 0.75rem 1.25rem;
+}
+
+.broker-positions table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.broker-positions th,
+.broker-positions td {
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  font-size: 0.8rem;
+}
+
+.broker-positions th {
+  color: #666;
+  font-weight: 600;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.expand-icon {
+  font-size: 0.8rem;
+  color: #999;
+  transition: transform 0.2s;
+}
+
+.expand-icon.expanded {
+  transform: rotate(180deg);
+}
+
+/* Allocation chart */
+.allocation-section {
+  margin-top: 1.5rem;
+}
+
+.allocation-section h3 {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+}
+
+.allocation-bar {
+  display: flex;
+  height: 32px;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.allocation-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  color: white;
+  font-weight: 600;
+  min-width: 2px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.allocation-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legend-value {
+  color: #666;
+}
+
+/* Empty state */
+.portfolio-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #666;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+.portfolio-empty p {
+  margin: 0.5rem 0;
+}

--- a/src/features/portfolio-view/ui/PortfolioPage.tsx
+++ b/src/features/portfolio-view/ui/PortfolioPage.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { PortfolioSummary } from './PortfolioSummary'
+import { HoldingsTable } from './HoldingsTable'
+import { BrokerBreakdown } from './BrokerBreakdown'
+import { AllocationChart } from './AllocationChart'
+import { getAllPositions, getBrokerAccounts } from '../services/portfolio-service'
+import { computeMetrics } from '../services/metrics-service'
+import './PortfolioPage.css'
+
+type View = 'summary' | 'holdings' | 'brokers'
+
+export function PortfolioPage() {
+  const [view, setView] = useState<View>('summary')
+
+  const positions = getAllPositions()
+  const metrics = computeMetrics(positions)
+  const accounts = getBrokerAccounts()
+
+  return (
+    <div className="portfolio-page">
+      <h2>Портфель</h2>
+
+      <PortfolioSummary metrics={metrics} />
+
+      <div className="portfolio-tabs">
+        <button
+          className={`portfolio-tab ${view === 'summary' ? 'active' : ''}`}
+          onClick={() => setView('summary')}
+        >
+          Обзор
+        </button>
+        <button
+          className={`portfolio-tab ${view === 'holdings' ? 'active' : ''}`}
+          onClick={() => setView('holdings')}
+        >
+          Все позиции
+        </button>
+        <button
+          className={`portfolio-tab ${view === 'brokers' ? 'active' : ''}`}
+          onClick={() => setView('brokers')}
+        >
+          По брокерам
+        </button>
+      </div>
+
+      {view === 'summary' && (
+        <div>
+          <AllocationChart
+            data={metrics.allocationByAssetClass}
+            title="Распределение по классам активов"
+          />
+          <AllocationChart
+            data={metrics.allocationBySector}
+            title="Распределение по секторам"
+          />
+        </div>
+      )}
+
+      {view === 'holdings' && <HoldingsTable positions={positions} />}
+
+      {view === 'brokers' && <BrokerBreakdown accounts={accounts} />}
+    </div>
+  )
+}

--- a/src/features/portfolio-view/ui/PortfolioSummary.tsx
+++ b/src/features/portfolio-view/ui/PortfolioSummary.tsx
@@ -1,0 +1,33 @@
+import type { PortfolioMetrics } from '../domain/models'
+import { formatRub, formatPercent, gainClass } from '../domain/formatters'
+
+interface PortfolioSummaryProps {
+  metrics: PortfolioMetrics
+}
+
+export function PortfolioSummary({ metrics }: PortfolioSummaryProps) {
+  return (
+    <div className="portfolio-summary">
+      <div className="summary-card">
+        <span className="summary-card-value">{formatRub(metrics.totalValue)}</span>
+        <span className="summary-card-label">Общая стоимость</span>
+      </div>
+      <div className="summary-card">
+        <span className={`summary-card-value ${gainClass(metrics.totalGain)}`}>
+          {formatRub(metrics.totalGain)}
+        </span>
+        <span className="summary-card-label">
+          Прибыль/Убыток ({formatPercent(metrics.totalGainPercent)})
+        </span>
+      </div>
+      <div className="summary-card">
+        <span className="summary-card-value">{metrics.positionCount}</span>
+        <span className="summary-card-label">Позиций</span>
+      </div>
+      <div className="summary-card">
+        <span className="summary-card-value">{metrics.brokerCount}</span>
+        <span className="summary-card-label">Брокеров</span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/portfolio-view/ui/__tests__/AllocationChart.test.tsx
+++ b/src/features/portfolio-view/ui/__tests__/AllocationChart.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AllocationChart } from '../AllocationChart'
+
+describe('AllocationChart', () => {
+  it('renders title and legend', () => {
+    const data = [
+      { category: 'Акции', percent: 60, value: 180000 },
+      { category: 'Облигации', percent: 40, value: 120000 },
+    ]
+    render(<AllocationChart data={data} title="Распределение" />)
+    expect(screen.getByText('Распределение')).toBeInTheDocument()
+    expect(screen.getByText('Акции')).toBeInTheDocument()
+    expect(screen.getByText('Облигации')).toBeInTheDocument()
+  })
+
+  it('shows percentage in segments when large enough', () => {
+    const data = [
+      { category: 'Акции', percent: 60, value: 180000 },
+      { category: 'Облигации', percent: 40, value: 120000 },
+    ]
+    render(<AllocationChart data={data} title="Test" />)
+    expect(screen.getByText('60%')).toBeInTheDocument()
+    expect(screen.getByText('40%')).toBeInTheDocument()
+  })
+
+  it('renders nothing when data is empty', () => {
+    const { container } = render(<AllocationChart data={[]} title="Test" />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/src/features/portfolio-view/ui/__tests__/BrokerBreakdown.test.tsx
+++ b/src/features/portfolio-view/ui/__tests__/BrokerBreakdown.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BrokerBreakdown } from '../BrokerBreakdown'
+import type { BrokerAccount } from '../../domain/models'
+
+const MOCK_ACCOUNTS: BrokerAccount[] = [
+  {
+    broker: 'sberbank', displayName: 'Сбербанк Инвестиции', accountType: 'standard',
+    positions: [
+      {
+        ticker: 'SBER', name: 'Сбербанк', broker: 'sberbank', accountType: 'standard',
+        assetClass: 'stock', sector: 'Финансы', currency: 'RUB',
+        quantity: 100, currentPrice: 300, currentValue: 30000, costBasis: 25000,
+        purchaseDate: '2024-01-01', dailyVolume: 1000000,
+        unrealizedGain: 5000, unrealizedGainPercent: 20, portfolioWeight: 100,
+      },
+    ],
+    totalValue: 30000, totalGain: 5000, positionCount: 1,
+  },
+  {
+    broker: 'vtb', displayName: 'ВТБ Мои Инвестиции', accountType: 'auto_managed',
+    positions: [
+      {
+        ticker: 'TBRU', name: 'Тинькофф Облигации', broker: 'vtb', accountType: 'auto_managed',
+        assetClass: 'etf', sector: 'Облигации', currency: 'RUB',
+        quantity: 1000, currentPrice: 5.5, currentValue: 5500, costBasis: 5000,
+        purchaseDate: '2024-10-01', dailyVolume: 5000000,
+        unrealizedGain: 500, unrealizedGainPercent: 10, portfolioWeight: 100,
+      },
+    ],
+    totalValue: 5500, totalGain: 500, positionCount: 1,
+  },
+]
+
+describe('BrokerBreakdown', () => {
+  it('renders all broker accounts', () => {
+    render(<BrokerBreakdown accounts={MOCK_ACCOUNTS} />)
+    expect(screen.getByText('Сбербанк Инвестиции')).toBeInTheDocument()
+    expect(screen.getByText('ВТБ Мои Инвестиции')).toBeInTheDocument()
+  })
+
+  it('shows account type badges', () => {
+    render(<BrokerBreakdown accounts={MOCK_ACCOUNTS} />)
+    expect(screen.getByText('Брокерский счёт')).toBeInTheDocument()
+    expect(screen.getByText('Инвест-копилка')).toBeInTheDocument()
+  })
+
+  it('expands broker to show positions when clicked', () => {
+    render(<BrokerBreakdown accounts={MOCK_ACCOUNTS} />)
+    fireEvent.click(screen.getByText('Сбербанк Инвестиции'))
+    expect(screen.getByText('SBER')).toBeInTheDocument()
+    expect(screen.getByText('Сбербанк')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no accounts', () => {
+    render(<BrokerBreakdown accounts={[]} />)
+    expect(screen.getByText('Нет подключённых брокеров.')).toBeInTheDocument()
+  })
+})

--- a/src/features/portfolio-view/ui/__tests__/HoldingsTable.test.tsx
+++ b/src/features/portfolio-view/ui/__tests__/HoldingsTable.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HoldingsTable } from '../HoldingsTable'
+import type { ViewPosition } from '../../domain/models'
+
+const MOCK_POSITIONS: ViewPosition[] = [
+  {
+    ticker: 'SBER', name: 'Сбербанк', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', sector: 'Финансы', currency: 'RUB',
+    quantity: 100, currentPrice: 300, currentValue: 30000, costBasis: 25000,
+    purchaseDate: '2024-01-01', dailyVolume: 1000000,
+    unrealizedGain: 5000, unrealizedGainPercent: 20, portfolioWeight: 60,
+  },
+  {
+    ticker: 'GAZP', name: 'Газпром', broker: 'tbank', accountType: 'standard',
+    assetClass: 'stock', sector: 'Нефть и газ', currency: 'RUB',
+    quantity: 200, currentPrice: 150, currentValue: 30000, costBasis: 35000,
+    purchaseDate: '2024-02-01', dailyVolume: 2000000,
+    unrealizedGain: -5000, unrealizedGainPercent: -14.29, portfolioWeight: 40,
+  },
+]
+
+describe('HoldingsTable', () => {
+  it('renders all positions', () => {
+    render(<HoldingsTable positions={MOCK_POSITIONS} />)
+    expect(screen.getByText('SBER')).toBeInTheDocument()
+    expect(screen.getByText('GAZP')).toBeInTheDocument()
+  })
+
+  it('renders column headers', () => {
+    render(<HoldingsTable positions={MOCK_POSITIONS} />)
+    expect(screen.getByText(/Тикер/)).toBeInTheDocument()
+    expect(screen.getByText(/Название/)).toBeInTheDocument()
+    expect(screen.getByText(/Стоимость/)).toBeInTheDocument()
+  })
+
+  it('shows empty state when no positions', () => {
+    render(<HoldingsTable positions={[]} />)
+    expect(screen.getByText('Нет позиций для отображения.')).toBeInTheDocument()
+  })
+
+  it('sorts by column when header is clicked', () => {
+    render(<HoldingsTable positions={MOCK_POSITIONS} />)
+    const tickerHeader = screen.getByText(/Тикер/)
+    fireEvent.click(tickerHeader)
+    // After clicking, sorting should be applied (visual check via sort indicator)
+    expect(screen.getByText('▼')).toBeInTheDocument()
+  })
+})

--- a/src/features/portfolio-view/ui/__tests__/PortfolioPage.test.tsx
+++ b/src/features/portfolio-view/ui/__tests__/PortfolioPage.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PortfolioPage } from '../PortfolioPage'
+
+describe('PortfolioPage', () => {
+  it('renders the page title', () => {
+    render(<PortfolioPage />)
+    expect(screen.getByText('Портфель')).toBeInTheDocument()
+  })
+
+  it('renders summary cards', () => {
+    render(<PortfolioPage />)
+    expect(screen.getByText('Общая стоимость')).toBeInTheDocument()
+    expect(screen.getByText('Позиций')).toBeInTheDocument()
+    expect(screen.getByText('Брокеров')).toBeInTheDocument()
+  })
+
+  it('renders navigation tabs', () => {
+    render(<PortfolioPage />)
+    expect(screen.getByText('Обзор')).toBeInTheDocument()
+    expect(screen.getByText('Все позиции')).toBeInTheDocument()
+    expect(screen.getByText('По брокерам')).toBeInTheDocument()
+  })
+
+  it('shows allocation charts on summary tab by default', () => {
+    render(<PortfolioPage />)
+    expect(screen.getByText('Распределение по классам активов')).toBeInTheDocument()
+    expect(screen.getByText('Распределение по секторам')).toBeInTheDocument()
+  })
+
+  it('switches to holdings view', () => {
+    render(<PortfolioPage />)
+    fireEvent.click(screen.getByText('Все позиции'))
+    expect(screen.getByText('Тикер')).toBeInTheDocument()
+    expect(screen.getByText('SBER')).toBeInTheDocument()
+  })
+
+  it('switches to broker view', () => {
+    render(<PortfolioPage />)
+    fireEvent.click(screen.getByText('По брокерам'))
+    expect(screen.getByText('Сбербанк Инвестиции')).toBeInTheDocument()
+    expect(screen.getByText('Т-Инвестиции')).toBeInTheDocument()
+  })
+})

--- a/src/features/portfolio-view/ui/__tests__/PortfolioSummary.test.tsx
+++ b/src/features/portfolio-view/ui/__tests__/PortfolioSummary.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PortfolioSummary } from '../PortfolioSummary'
+import type { PortfolioMetrics } from '../../domain/models'
+
+const MOCK_METRICS: PortfolioMetrics = {
+  totalValue: 330910,
+  totalCostBasis: 300700,
+  totalGain: 30210,
+  totalGainPercent: 10.05,
+  positionCount: 15,
+  brokerCount: 4,
+  allocationByAssetClass: [],
+  allocationBySector: [],
+  topHoldings: [],
+}
+
+describe('PortfolioSummary', () => {
+  it('renders total value', () => {
+    render(<PortfolioSummary metrics={MOCK_METRICS} />)
+    expect(screen.getByText('Общая стоимость')).toBeInTheDocument()
+  })
+
+  it('renders position and broker counts', () => {
+    render(<PortfolioSummary metrics={MOCK_METRICS} />)
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('renders gain/loss label', () => {
+    render(<PortfolioSummary metrics={MOCK_METRICS} />)
+    expect(screen.getByText(/Прибыль\/Убыток/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- operum-agent: engineer -->
## Summary

Implements the portfolio view screen — the main landing page for the investment app.

Closes #1

## Changes

### Domain Layer
- `models.ts` — Canonical types for ViewPosition, BrokerAccount, PortfolioMetrics
- `formatters.ts` — RUB currency formatting, percent display, gain/loss helpers, Russian labels

### Service Layer
- `portfolio-service.ts` — Mock data with 15 positions across 4 Russian brokers
- `metrics-service.ts` — Pure computation for totals, allocation breakdowns, top holdings

### UI Components
- `PortfolioPage.tsx` — Main page with tab navigation (Обзор / Все позиции / По брокерам)
- `PortfolioSummary.tsx` — Summary cards (total value, gain/loss, counts)
- `HoldingsTable.tsx` — Sortable positions table
- `BrokerBreakdown.tsx` — Expandable broker cards with account type badges
- `AllocationChart.tsx` — CSS-only stacked bar chart with legend

### Navigation
- Updated App.tsx with portfolio as default landing tab

### Tests
- 7 test files covering domain, services, and all UI components

---
*Software Engineer - Operum AI*