### PR TITLE
feat(analytics): add analytics and reports system (#4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,9 @@ import { DiversificationDashboard } from './features/diversification/ui/Diversif
 import { ProfitabilityDashboard } from './features/profitability/ui/ProfitabilityDashboard'
 import { MarketDataPage } from './features/market-data/ui/MarketDataPage'
 import { BrokerPage } from './features/broker-integration/ui/BrokerPage'
+import { AnalyticsPage } from './features/analytics/ui/AnalyticsPage'
 
-type Page = 'portfolio' | 'allocation' | 'diversification' | 'optimization' | 'profitability' | 'market' | 'brokers'
+type Page = 'portfolio' | 'allocation' | 'diversification' | 'optimization' | 'profitability' | 'market' | 'brokers' | 'analytics'
 
 export function App() {
   const [page, setPage] = useState<Page>('portfolio')
@@ -54,6 +55,12 @@ export function App() {
             Биржа
           </button>
           <button
+            className={`nav-btn ${page === 'analytics' ? 'active' : ''}`}
+            onClick={() => setPage('analytics')}
+          >
+            Аналитика
+          </button>
+          <button
             className={`nav-btn ${page === 'brokers' ? 'active' : ''}`}
             onClick={() => setPage('brokers')}
           >
@@ -72,6 +79,7 @@ export function App() {
         )}
         {page === 'profitability' && <ProfitabilityDashboard />}
         {page === 'market' && <MarketDataPage />}
+        {page === 'analytics' && <AnalyticsPage />}
         {page === 'brokers' && <BrokerPage />}
       </main>
     </div>

--- a/src/features/analytics/domain/constants.ts
+++ b/src/features/analytics/domain/constants.ts
@@ -1,0 +1,55 @@
+export { NDFL_RATE, NDFL_HIGH_RATE, NDFL_HIGH_INCOME_THRESHOLD, TAX_EXEMPT_HOLDING_YEARS } from '@/features/portfolio-optimization/domain/constants'
+
+export const TRADING_DAYS_PER_YEAR = 252
+
+export const RISK_FREE_RATE = 0.16
+
+export const BENCHMARK_IMOEX = {
+  id: 'IMOEX' as const,
+  name: 'Индекс МосБиржи',
+}
+
+export const ANALYSIS_PERIODS = {
+  '1M': { label: '1М', days: 30 },
+  '3M': { label: '3М', days: 90 },
+  '6M': { label: '6М', days: 180 },
+  '1Y': { label: '1Г', days: 365 },
+  'YTD': { label: 'С нач. года', days: 0 },
+  'ALL': { label: 'Всё', days: 0 },
+} as const
+
+export const ASSET_CLASS_COLORS: Record<string, string> = {
+  'Акции': '#1976d2',
+  'Облигации': '#2e7d32',
+  'ETF': '#f57c00',
+  'Валюта': '#7b1fa2',
+  'Прочее': '#757575',
+}
+
+export const SECTOR_COLORS: Record<string, string> = {
+  'Финансы': '#1976d2',
+  'Нефть и газ': '#2e7d32',
+  'Технологии': '#f57c00',
+  'Металлургия': '#7b1fa2',
+  'Потребительский': '#00838f',
+  'Гос. облигации': '#5d4037',
+  'Облигации': '#455a64',
+  'Широкий рынок': '#e65100',
+  'Денежный рынок': '#1b5e20',
+}
+
+export const GEOGRAPHY_REGIONS: Record<string, string> = {
+  'Россия': '#1976d2',
+  'США': '#f44336',
+  'Китай': '#ff9800',
+  'Европа': '#4caf50',
+  'Прочее': '#757575',
+}
+
+export const CORRELATION_COLORS = {
+  strongPositive: '#1b5e20',
+  positive: '#66bb6a',
+  neutral: '#e0e0e0',
+  negative: '#ef5350',
+  strongNegative: '#b71c1c',
+} as const

--- a/src/features/analytics/domain/models.ts
+++ b/src/features/analytics/domain/models.ts
@@ -1,0 +1,132 @@
+import type { ViewPosition } from '@/features/portfolio-view/domain/models'
+
+export interface TimeSeriesPoint {
+  date: string
+  value: number
+}
+
+export interface TimeSeries {
+  points: TimeSeriesPoint[]
+  startDate: string
+  endDate: string
+  periodReturn: number
+}
+
+export type AnalysisPeriod = '1M' | '3M' | '6M' | '1Y' | 'YTD' | 'ALL'
+
+export interface PortfolioSnapshot {
+  date: string
+  totalValue: number
+  positions: ViewPosition[]
+}
+
+export interface RiskMetrics {
+  volatility: number
+  sharpeRatio: number
+  maxDrawdown: number
+  maxDrawdownPeriod: {
+    peakDate: string
+    troughDate: string
+  }
+  beta?: number
+}
+
+export interface CorrelationEntry {
+  tickerA: string
+  tickerB: string
+  correlation: number
+}
+
+export interface CorrelationMatrix {
+  tickers: string[]
+  values: number[][]
+}
+
+export type BenchmarkId = 'IMOEX'
+
+export interface BenchmarkComparison {
+  benchmarkId: BenchmarkId
+  benchmarkName: string
+  portfolioSeries: TimeSeries
+  benchmarkSeries: TimeSeries
+  portfolioReturn: number
+  benchmarkReturn: number
+  alpha: number
+}
+
+export interface AllocationBreakdown {
+  category: string
+  value: number
+  percent: number
+  color: string
+}
+
+export interface GeographyBreakdown {
+  region: string
+  value: number
+  percent: number
+}
+
+export interface TaxReport {
+  period: { year: number; quarter?: number }
+  dividendIncome: number
+  dividendTax: number
+  capitalGains: number
+  capitalGainsTax: number
+  taxExemptGains: number
+  totalTaxLiability: number
+  transactions: TaxableTransaction[]
+}
+
+export interface TaxableTransaction {
+  date: string
+  ticker: string
+  type: 'dividend' | 'sale'
+  amount: number
+  taxAmount: number
+  isExempt: boolean
+  exemptReason?: string
+}
+
+export type ReportPeriodType = 'monthly' | 'quarterly' | 'yearly'
+
+export interface ReportConfig {
+  periodType: ReportPeriodType
+  year: number
+  month?: number
+  quarter?: number
+  includeCharts: boolean
+  includeTaxBreakdown: boolean
+  includeTransactions: boolean
+}
+
+export interface GeneratedReport {
+  config: ReportConfig
+  generatedAt: string
+  metrics: RiskMetrics
+  allocation: AllocationBreakdown[]
+  portfolioReturn: number
+  benchmarkReturn?: number
+  taxSummary?: TaxReport
+  transactions?: TaxableTransaction[]
+}
+
+export interface AnalyticsInput {
+  snapshots: PortfolioSnapshot[]
+  positions: ViewPosition[]
+  benchmarkData?: TimeSeries
+  transactions?: TaxableTransaction[]
+  period: AnalysisPeriod
+}
+
+export interface AnalyticsResult {
+  portfolioTimeSeries: TimeSeries
+  riskMetrics: RiskMetrics
+  benchmark?: BenchmarkComparison
+  allocation: {
+    byAssetClass: AllocationBreakdown[]
+    bySector: AllocationBreakdown[]
+    byGeography: GeographyBreakdown[]
+  }
+  correlationMatrix?: CorrelationMatrix
+}

--- a/src/features/analytics/engines/__tests__/benchmark-engine.test.ts
+++ b/src/features/analytics/engines/__tests__/benchmark-engine.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeSeries, compareToBenchmark } from '../benchmark-engine'
+import type { TimeSeries } from '../../domain/models'
+
+describe('benchmark-engine', () => {
+  it('normalizes series to base 100', () => {
+    const series: TimeSeries = {
+      points: [
+        { date: '2025-01-01', value: 200 },
+        { date: '2025-01-02', value: 220 },
+        { date: '2025-01-03', value: 210 },
+      ],
+      startDate: '2025-01-01',
+      endDate: '2025-01-03',
+      periodReturn: 5,
+    }
+    const normalized = normalizeSeries(series)
+    expect(normalized.points[0]!.value).toBe(100)
+    expect(normalized.points[1]!.value).toBe(110)
+    expect(normalized.points[2]!.value).toBe(105)
+  })
+
+  it('handles empty series', () => {
+    const series: TimeSeries = {
+      points: [],
+      startDate: '',
+      endDate: '',
+      periodReturn: 0,
+    }
+    const normalized = normalizeSeries(series)
+    expect(normalized.points).toHaveLength(0)
+  })
+
+  it('compares portfolio to benchmark', () => {
+    const portfolio: TimeSeries = {
+      points: [
+        { date: '2025-01-01', value: 100000 },
+        { date: '2025-01-02', value: 115000 },
+      ],
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      periodReturn: 15,
+    }
+    const benchmark: TimeSeries = {
+      points: [
+        { date: '2025-01-01', value: 3200 },
+        { date: '2025-01-02', value: 3520 },
+      ],
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      periodReturn: 10,
+    }
+    const comparison = compareToBenchmark(portfolio, benchmark)
+    expect(comparison.portfolioReturn).toBe(15)
+    expect(comparison.benchmarkReturn).toBe(10)
+    expect(comparison.alpha).toBe(5)
+    expect(comparison.benchmarkName).toBe('Индекс МосБиржи')
+  })
+})

--- a/src/features/analytics/engines/__tests__/risk-metrics-engine.test.ts
+++ b/src/features/analytics/engines/__tests__/risk-metrics-engine.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeVolatility,
+  computeSharpeRatio,
+  computeMaxDrawdown,
+  computeCorrelationMatrix,
+  computeRiskMetrics,
+} from '../risk-metrics-engine'
+import type { TimeSeriesPoint } from '../../domain/models'
+
+describe('risk-metrics-engine', () => {
+  it('computes volatility for daily returns', () => {
+    const returns = [0.01, -0.005, 0.02, -0.01, 0.015, -0.008, 0.012]
+    const vol = computeVolatility(returns)
+    expect(vol).toBeGreaterThan(0)
+    expect(vol).toBeLessThan(100)
+  })
+
+  it('returns 0 volatility for insufficient data', () => {
+    expect(computeVolatility([])).toBe(0)
+    expect(computeVolatility([0.01])).toBe(0)
+  })
+
+  it('computes Sharpe ratio', () => {
+    const returns = [0.01, 0.015, 0.008, 0.012, 0.009, 0.011, 0.013]
+    const sharpe = computeSharpeRatio(returns, 0.05)
+    expect(typeof sharpe).toBe('number')
+  })
+
+  it('computes max drawdown', () => {
+    const series: TimeSeriesPoint[] = [
+      { date: '2025-01-01', value: 100 },
+      { date: '2025-01-02', value: 110 },
+      { date: '2025-01-03', value: 95 },
+      { date: '2025-01-04', value: 105 },
+      { date: '2025-01-05', value: 108 },
+    ]
+    const result = computeMaxDrawdown(series)
+    expect(result.maxDrawdown).toBeGreaterThan(0)
+    expect(result.peakDate).toBe('2025-01-02')
+    expect(result.troughDate).toBe('2025-01-03')
+  })
+
+  it('returns 0 drawdown for monotonically increasing', () => {
+    const series: TimeSeriesPoint[] = [
+      { date: '2025-01-01', value: 100 },
+      { date: '2025-01-02', value: 110 },
+      { date: '2025-01-03', value: 120 },
+    ]
+    const result = computeMaxDrawdown(series)
+    expect(result.maxDrawdown).toBe(0)
+  })
+
+  it('computes correlation matrix', () => {
+    const data = new Map<string, number[]>()
+    data.set('A', [0.01, 0.02, -0.01, 0.015, -0.005])
+    data.set('B', [0.01, 0.018, -0.008, 0.012, -0.003])
+    data.set('C', [-0.01, -0.02, 0.01, -0.015, 0.005])
+
+    const matrix = computeCorrelationMatrix(data)
+    expect(matrix.tickers).toEqual(['A', 'B', 'C'])
+    expect(matrix.values).toHaveLength(3)
+    // Diagonal should be 1
+    expect(matrix.values[0]![0]).toBe(1)
+    expect(matrix.values[1]![1]).toBe(1)
+    // A and B should be positively correlated
+    expect(matrix.values[0]![1]).toBeGreaterThan(0)
+    // A and C should be negatively correlated
+    expect(matrix.values[0]![2]).toBeLessThan(0)
+  })
+
+  it('computes risk metrics from points', () => {
+    const points: TimeSeriesPoint[] = Array.from({ length: 30 }, (_, i) => ({
+      date: `2025-01-${String(i + 1).padStart(2, '0')}`,
+      value: 100000 + Math.sin(i * 0.5) * 2000,
+    }))
+    const metrics = computeRiskMetrics(points)
+    expect(metrics.volatility).toBeGreaterThan(0)
+    expect(metrics.maxDrawdown).toBeGreaterThanOrEqual(0)
+    expect(typeof metrics.sharpeRatio).toBe('number')
+  })
+})

--- a/src/features/analytics/engines/__tests__/tax-engine.test.ts
+++ b/src/features/analytics/engines/__tests__/tax-engine.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { computeDividendTax, computeCapitalGainsTax, computeTaxReport } from '../tax-engine'
+import type { TaxableTransaction } from '../../domain/models'
+
+describe('tax-engine', () => {
+  it('computes 13% dividend tax for normal income', () => {
+    const tax = computeDividendTax(10000, 1000000)
+    expect(tax).toBe(1300)
+  })
+
+  it('computes 15% dividend tax for high income', () => {
+    const tax = computeDividendTax(10000, 6000000)
+    expect(tax).toBe(1500)
+  })
+
+  it('computes capital gains tax', () => {
+    const result = computeCapitalGainsTax(50000, 40000, '2025-01-01', 1000000)
+    expect(result.tax).toBe(1300)
+    expect(result.isExempt).toBe(false)
+  })
+
+  it('exempts long-term holdings', () => {
+    const result = computeCapitalGainsTax(50000, 40000, '2020-01-01', 1000000)
+    expect(result.tax).toBe(0)
+    expect(result.isExempt).toBe(true)
+    expect(result.exemptReason).toBe('3+ года владения')
+  })
+
+  it('returns 0 tax for losses', () => {
+    const result = computeCapitalGainsTax(30000, 40000, '2025-01-01', 1000000)
+    expect(result.tax).toBe(0)
+    expect(result.isExempt).toBe(false)
+  })
+
+  it('computes tax report for a period', () => {
+    const transactions: TaxableTransaction[] = [
+      { date: '2025-03-15', ticker: 'SBER', type: 'dividend', amount: 10000, taxAmount: 1300, isExempt: false },
+      { date: '2025-06-20', ticker: 'LKOH', type: 'dividend', amount: 5000, taxAmount: 650, isExempt: false },
+      { date: '2025-04-10', ticker: 'GAZP', type: 'sale', amount: 3000, taxAmount: 390, isExempt: false },
+      { date: '2024-12-01', ticker: 'MGNT', type: 'dividend', amount: 2000, taxAmount: 260, isExempt: false },
+    ]
+
+    const report = computeTaxReport(transactions, { year: 2025 })
+    expect(report.dividendIncome).toBe(15000)
+    expect(report.dividendTax).toBe(1950)
+    expect(report.capitalGains).toBe(3000)
+    expect(report.capitalGainsTax).toBe(390)
+    expect(report.totalTaxLiability).toBe(2340)
+    expect(report.transactions).toHaveLength(3)
+  })
+
+  it('filters by quarter', () => {
+    const transactions: TaxableTransaction[] = [
+      { date: '2025-01-15', ticker: 'A', type: 'dividend', amount: 1000, taxAmount: 130, isExempt: false },
+      { date: '2025-04-15', ticker: 'B', type: 'dividend', amount: 2000, taxAmount: 260, isExempt: false },
+    ]
+
+    const q1 = computeTaxReport(transactions, { year: 2025, quarter: 1 })
+    expect(q1.transactions).toHaveLength(1)
+    expect(q1.dividendIncome).toBe(1000)
+
+    const q2 = computeTaxReport(transactions, { year: 2025, quarter: 2 })
+    expect(q2.transactions).toHaveLength(1)
+    expect(q2.dividendIncome).toBe(2000)
+  })
+
+  it('counts exempt gains separately', () => {
+    const transactions: TaxableTransaction[] = [
+      { date: '2025-05-01', ticker: 'X', type: 'sale', amount: 5000, taxAmount: 0, isExempt: true, exemptReason: '3+ года' },
+    ]
+    const report = computeTaxReport(transactions, { year: 2025 })
+    expect(report.taxExemptGains).toBe(5000)
+    expect(report.capitalGains).toBe(0)
+    expect(report.totalTaxLiability).toBe(0)
+  })
+})

--- a/src/features/analytics/engines/__tests__/time-series-engine.test.ts
+++ b/src/features/analytics/engines/__tests__/time-series-engine.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { buildTimeSeries, filterByPeriod, computePeriodReturn, dailyReturnsFromSeries } from '../time-series-engine'
+import type { PortfolioSnapshot, TimeSeries, TimeSeriesPoint } from '../../domain/models'
+
+function makeSnapshots(count: number, startValue: number, endValue: number): PortfolioSnapshot[] {
+  const snapshots: PortfolioSnapshot[] = []
+  const now = new Date()
+  for (let i = count; i >= 0; i--) {
+    const date = new Date(now)
+    date.setDate(date.getDate() - i)
+    const progress = (count - i) / count
+    const value = startValue + (endValue - startValue) * progress
+    snapshots.push({
+      date: date.toISOString().split('T')[0]!,
+      totalValue: value,
+      positions: [],
+    })
+  }
+  return snapshots
+}
+
+describe('time-series-engine', () => {
+  it('builds time series from snapshots', () => {
+    const snapshots = makeSnapshots(30, 100000, 110000)
+    const series = buildTimeSeries(snapshots, 'ALL')
+    expect(series.points.length).toBe(snapshots.length)
+    expect(series.periodReturn).toBeGreaterThan(0)
+  })
+
+  it('returns empty series for empty input', () => {
+    const series = buildTimeSeries([], 'ALL')
+    expect(series.points).toHaveLength(0)
+    expect(series.periodReturn).toBe(0)
+  })
+
+  it('filters by period', () => {
+    const snapshots = makeSnapshots(365, 100000, 120000)
+    const allSeries = buildTimeSeries(snapshots, 'ALL')
+    const filtered = filterByPeriod(allSeries, '1M')
+    expect(filtered.points.length).toBeLessThan(allSeries.points.length)
+    expect(filtered.points.length).toBeGreaterThan(0)
+  })
+
+  it('computes period return', () => {
+    const series: TimeSeries = {
+      points: [
+        { date: '2025-01-01', value: 100 },
+        { date: '2025-01-02', value: 110 },
+      ],
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      periodReturn: 0,
+    }
+    expect(computePeriodReturn(series)).toBe(10)
+  })
+
+  it('returns 0 for single point', () => {
+    const series: TimeSeries = {
+      points: [{ date: '2025-01-01', value: 100 }],
+      startDate: '2025-01-01',
+      endDate: '2025-01-01',
+      periodReturn: 0,
+    }
+    expect(computePeriodReturn(series)).toBe(0)
+  })
+
+  it('computes daily returns', () => {
+    const points: TimeSeriesPoint[] = [
+      { date: '2025-01-01', value: 100 },
+      { date: '2025-01-02', value: 105 },
+      { date: '2025-01-03', value: 110 },
+    ]
+    const returns = dailyReturnsFromSeries(points)
+    expect(returns).toHaveLength(2)
+    expect(returns[0]).toBeCloseTo(0.05)
+  })
+})

--- a/src/features/analytics/engines/benchmark-engine.ts
+++ b/src/features/analytics/engines/benchmark-engine.ts
@@ -1,0 +1,37 @@
+import type { TimeSeries, BenchmarkComparison } from '../domain/models'
+import { BENCHMARK_IMOEX } from '../domain/constants'
+
+export function normalizeSeries(series: TimeSeries): TimeSeries {
+  if (series.points.length === 0) return series
+  const baseValue = series.points[0]!.value
+  if (baseValue === 0) return series
+
+  return {
+    ...series,
+    points: series.points.map(p => ({
+      date: p.date,
+      value: (p.value / baseValue) * 100,
+    })),
+  }
+}
+
+export function compareToBenchmark(
+  portfolioSeries: TimeSeries,
+  benchmarkSeries: TimeSeries,
+): BenchmarkComparison {
+  const normalizedPortfolio = normalizeSeries(portfolioSeries)
+  const normalizedBenchmark = normalizeSeries(benchmarkSeries)
+
+  const portfolioReturn = portfolioSeries.periodReturn
+  const benchmarkReturn = benchmarkSeries.periodReturn
+
+  return {
+    benchmarkId: BENCHMARK_IMOEX.id,
+    benchmarkName: BENCHMARK_IMOEX.name,
+    portfolioSeries: normalizedPortfolio,
+    benchmarkSeries: normalizedBenchmark,
+    portfolioReturn,
+    benchmarkReturn,
+    alpha: portfolioReturn - benchmarkReturn,
+  }
+}

--- a/src/features/analytics/engines/risk-metrics-engine.ts
+++ b/src/features/analytics/engines/risk-metrics-engine.ts
@@ -1,0 +1,115 @@
+import type { RiskMetrics, TimeSeriesPoint, CorrelationMatrix } from '../domain/models'
+import { TRADING_DAYS_PER_YEAR, RISK_FREE_RATE } from '../domain/constants'
+import { dailyReturnsFromSeries } from './time-series-engine'
+
+export function computeVolatility(dailyReturns: number[]): number {
+  if (dailyReturns.length < 2) return 0
+  const mean = dailyReturns.reduce((s, r) => s + r, 0) / dailyReturns.length
+  const variance = dailyReturns.reduce((s, r) => s + (r - mean) ** 2, 0) / (dailyReturns.length - 1)
+  return Math.sqrt(variance) * Math.sqrt(TRADING_DAYS_PER_YEAR) * 100
+}
+
+export function computeSharpeRatio(dailyReturns: number[], riskFreeRate: number): number {
+  if (dailyReturns.length < 2) return 0
+  const annualizedReturn = computeAnnualizedReturn(dailyReturns)
+  const volatility = computeVolatility(dailyReturns) / 100
+  if (volatility === 0) return 0
+  return (annualizedReturn - riskFreeRate) / volatility
+}
+
+function computeAnnualizedReturn(dailyReturns: number[]): number {
+  if (dailyReturns.length === 0) return 0
+  const totalReturn = dailyReturns.reduce((prod, r) => prod * (1 + r), 1) - 1
+  const years = dailyReturns.length / TRADING_DAYS_PER_YEAR
+  if (years === 0) return 0
+  return Math.pow(1 + totalReturn, 1 / years) - 1
+}
+
+export function computeMaxDrawdown(
+  series: TimeSeriesPoint[],
+): { maxDrawdown: number; peakDate: string; troughDate: string } {
+  if (series.length < 2) {
+    return { maxDrawdown: 0, peakDate: '', troughDate: '' }
+  }
+
+  let maxDrawdown = 0
+  let peakValue = series[0]!.value
+  let peakDate = series[0]!.date
+  let resultPeakDate = ''
+  let resultTroughDate = ''
+
+  for (let i = 1; i < series.length; i++) {
+    const point = series[i]!
+    if (point.value > peakValue) {
+      peakValue = point.value
+      peakDate = point.date
+    }
+    const drawdown = peakValue > 0 ? ((peakValue - point.value) / peakValue) * 100 : 0
+    if (drawdown > maxDrawdown) {
+      maxDrawdown = drawdown
+      resultPeakDate = peakDate
+      resultTroughDate = point.date
+    }
+  }
+
+  return { maxDrawdown, peakDate: resultPeakDate, troughDate: resultTroughDate }
+}
+
+export function computeCorrelationMatrix(
+  assetReturns: Map<string, number[]>,
+): CorrelationMatrix {
+  const tickers = [...assetReturns.keys()]
+  const n = tickers.length
+  const values: number[][] = Array.from({ length: n }, () => Array(n).fill(0) as number[])
+
+  for (let i = 0; i < n; i++) {
+    values[i]![i] = 1.0
+    for (let j = i + 1; j < n; j++) {
+      const returnsA = assetReturns.get(tickers[i]!)!
+      const returnsB = assetReturns.get(tickers[j]!)!
+      const corr = pearsonCorrelation(returnsA, returnsB)
+      values[i]![j] = corr
+      values[j]![i] = corr
+    }
+  }
+
+  return { tickers, values }
+}
+
+function pearsonCorrelation(x: number[], y: number[]): number {
+  const n = Math.min(x.length, y.length)
+  if (n < 2) return 0
+
+  const meanX = x.slice(0, n).reduce((s, v) => s + v, 0) / n
+  const meanY = y.slice(0, n).reduce((s, v) => s + v, 0) / n
+
+  let sumXY = 0
+  let sumX2 = 0
+  let sumY2 = 0
+  for (let i = 0; i < n; i++) {
+    const dx = x[i]! - meanX
+    const dy = y[i]! - meanY
+    sumXY += dx * dy
+    sumX2 += dx * dx
+    sumY2 += dy * dy
+  }
+
+  const denom = Math.sqrt(sumX2 * sumY2)
+  if (denom === 0) return 0
+  return sumXY / denom
+}
+
+export function computeRiskMetrics(points: TimeSeriesPoint[]): RiskMetrics {
+  const dailyReturns = dailyReturnsFromSeries(points)
+  const drawdown = computeMaxDrawdown(points)
+
+  return {
+    volatility: computeVolatility(dailyReturns),
+    sharpeRatio: computeSharpeRatio(dailyReturns, RISK_FREE_RATE),
+    maxDrawdown: drawdown.maxDrawdown,
+    maxDrawdownPeriod: {
+      peakDate: drawdown.peakDate,
+      troughDate: drawdown.troughDate,
+    },
+  }
+}

--- a/src/features/analytics/engines/tax-engine.ts
+++ b/src/features/analytics/engines/tax-engine.ts
@@ -1,0 +1,79 @@
+import type { TaxReport, TaxableTransaction } from '../domain/models'
+import {
+  NDFL_RATE,
+  NDFL_HIGH_RATE,
+  NDFL_HIGH_INCOME_THRESHOLD,
+  TAX_EXEMPT_HOLDING_YEARS,
+} from '../domain/constants'
+
+export function computeDividendTax(amount: number, annualIncome: number): number {
+  const rate = annualIncome > NDFL_HIGH_INCOME_THRESHOLD ? NDFL_HIGH_RATE : NDFL_RATE
+  return Math.round(amount * rate * 100) / 100
+}
+
+export function computeCapitalGainsTax(
+  sellAmount: number,
+  costBasis: number,
+  purchaseDate: string,
+  annualIncome: number,
+): { tax: number; isExempt: boolean; exemptReason?: string } {
+  const gain = sellAmount - costBasis
+  if (gain <= 0) return { tax: 0, isExempt: false }
+
+  const purchaseDateObj = new Date(purchaseDate)
+  const now = new Date()
+  const holdingYears = (now.getTime() - purchaseDateObj.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
+
+  if (holdingYears >= TAX_EXEMPT_HOLDING_YEARS) {
+    return { tax: 0, isExempt: true, exemptReason: '3+ года владения' }
+  }
+
+  const rate = annualIncome > NDFL_HIGH_INCOME_THRESHOLD ? NDFL_HIGH_RATE : NDFL_RATE
+  return { tax: Math.round(gain * rate * 100) / 100, isExempt: false }
+}
+
+export function computeTaxReport(
+  transactions: TaxableTransaction[],
+  period: { year: number; quarter?: number },
+): TaxReport {
+  const filtered = transactions.filter(t => {
+    const txDate = new Date(t.date)
+    if (txDate.getFullYear() !== period.year) return false
+    if (period.quarter !== undefined) {
+      const txQuarter = Math.ceil((txDate.getMonth() + 1) / 3)
+      return txQuarter === period.quarter
+    }
+    return true
+  })
+
+  let dividendIncome = 0
+  let dividendTax = 0
+  let capitalGains = 0
+  let capitalGainsTax = 0
+  let taxExemptGains = 0
+
+  for (const tx of filtered) {
+    if (tx.type === 'dividend') {
+      dividendIncome += tx.amount
+      dividendTax += tx.taxAmount
+    } else {
+      if (tx.isExempt) {
+        taxExemptGains += tx.amount
+      } else {
+        capitalGains += tx.amount
+        capitalGainsTax += tx.taxAmount
+      }
+    }
+  }
+
+  return {
+    period,
+    dividendIncome: Math.round(dividendIncome * 100) / 100,
+    dividendTax: Math.round(dividendTax * 100) / 100,
+    capitalGains: Math.round(capitalGains * 100) / 100,
+    capitalGainsTax: Math.round(capitalGainsTax * 100) / 100,
+    taxExemptGains: Math.round(taxExemptGains * 100) / 100,
+    totalTaxLiability: Math.round((dividendTax + capitalGainsTax) * 100) / 100,
+    transactions: filtered,
+  }
+}

--- a/src/features/analytics/engines/time-series-engine.ts
+++ b/src/features/analytics/engines/time-series-engine.ts
@@ -1,0 +1,78 @@
+import type { TimeSeries, TimeSeriesPoint, PortfolioSnapshot, AnalysisPeriod } from '../domain/models'
+import { ANALYSIS_PERIODS } from '../domain/constants'
+
+export function buildTimeSeries(
+  snapshots: PortfolioSnapshot[],
+  period: AnalysisPeriod,
+): TimeSeries {
+  if (snapshots.length === 0) {
+    return { points: [], startDate: '', endDate: '', periodReturn: 0 }
+  }
+
+  const sorted = [...snapshots].sort((a, b) => a.date.localeCompare(b.date))
+  const points: TimeSeriesPoint[] = sorted.map(s => ({
+    date: s.date,
+    value: s.totalValue,
+  }))
+
+  const filtered = filterByPeriod(
+    { points, startDate: points[0]!.date, endDate: points[points.length - 1]!.date, periodReturn: 0 },
+    period,
+  )
+
+  return {
+    ...filtered,
+    periodReturn: computePeriodReturn(filtered),
+  }
+}
+
+export function filterByPeriod(series: TimeSeries, period: AnalysisPeriod): TimeSeries {
+  if (series.points.length === 0) return series
+
+  const endDate = new Date(series.endDate)
+  let startDate: Date
+
+  if (period === 'ALL') {
+    return series
+  } else if (period === 'YTD') {
+    startDate = new Date(endDate.getFullYear(), 0, 1)
+  } else {
+    const config = ANALYSIS_PERIODS[period]
+    startDate = new Date(endDate)
+    startDate.setDate(startDate.getDate() - config.days)
+  }
+
+  const startStr = startDate.toISOString().split('T')[0]!
+  const filtered = series.points.filter(p => p.date >= startStr)
+
+  if (filtered.length === 0) return { points: [], startDate: '', endDate: '', periodReturn: 0 }
+
+  return {
+    points: filtered,
+    startDate: filtered[0]!.date,
+    endDate: filtered[filtered.length - 1]!.date,
+    periodReturn: 0,
+  }
+}
+
+export function computePeriodReturn(series: TimeSeries): number {
+  if (series.points.length < 2) return 0
+  const first = series.points[0]!.value
+  const last = series.points[series.points.length - 1]!.value
+  if (first === 0) return 0
+  return ((last - first) / first) * 100
+}
+
+export function dailyReturnsFromSeries(points: TimeSeriesPoint[]): number[] {
+  const returns: number[] = []
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1]!.value
+    const curr = points[i]!.value
+    if (prev === 0) {
+      returns.push(0)
+    } else {
+      returns.push((curr - prev) / prev)
+    }
+  }
+  return returns
+}

--- a/src/features/analytics/index.ts
+++ b/src/features/analytics/index.ts
@@ -1,0 +1,14 @@
+export { AnalyticsPage } from './ui/AnalyticsPage'
+export type {
+  AnalysisPeriod,
+  AnalyticsResult,
+  RiskMetrics,
+  TimeSeries,
+  TimeSeriesPoint,
+  BenchmarkComparison,
+  AllocationBreakdown,
+  GeographyBreakdown,
+  TaxReport,
+  GeneratedReport,
+  CorrelationMatrix,
+} from './domain/models'

--- a/src/features/analytics/services/__tests__/analytics-service.test.ts
+++ b/src/features/analytics/services/__tests__/analytics-service.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { runAnalytics } from '../analytics-service'
+import type { AnalyticsInput, PortfolioSnapshot } from '../../domain/models'
+import type { ViewPosition } from '@/features/portfolio-view/domain/models'
+
+const mockPositions: ViewPosition[] = [
+  {
+    ticker: 'SBER', name: 'Сбербанк', broker: 'sberbank', accountType: 'standard',
+    assetClass: 'stock', sector: 'Финансы', currency: 'RUB',
+    quantity: 100, currentPrice: 295, currentValue: 29500, costBasis: 24000,
+    purchaseDate: '2024-03-15', dailyVolume: 45000000,
+    unrealizedGain: 5500, unrealizedGainPercent: 22.9, portfolioWeight: 50,
+  },
+  {
+    ticker: 'SU26238', name: 'ОФЗ 26238', broker: 'alfa', accountType: 'iis',
+    assetClass: 'bond', assetSubclass: 'ofz', sector: 'Гос. облигации', currency: 'RUB',
+    quantity: 50, currentPrice: 620, currentValue: 31000, costBasis: 30000,
+    purchaseDate: '2024-06-01', dailyVolume: 500000,
+    unrealizedGain: 1000, unrealizedGainPercent: 3.33, portfolioWeight: 50,
+  },
+]
+
+function makeSnapshots(positions: ViewPosition[]): PortfolioSnapshot[] {
+  const snapshots: PortfolioSnapshot[] = []
+  const now = new Date()
+  for (let i = 30; i >= 0; i--) {
+    const date = new Date(now)
+    date.setDate(date.getDate() - i)
+    const total = positions.reduce((s, p) => s + p.currentValue, 0)
+    const noise = Math.sin(i * 0.5) * 500
+    snapshots.push({
+      date: date.toISOString().split('T')[0]!,
+      totalValue: total + noise,
+      positions,
+    })
+  }
+  return snapshots
+}
+
+describe('analytics-service', () => {
+  it('computes analytics result', () => {
+    const input: AnalyticsInput = {
+      snapshots: makeSnapshots(mockPositions),
+      positions: mockPositions,
+      period: 'ALL',
+    }
+    const result = runAnalytics(input)
+    expect(result.portfolioTimeSeries.points.length).toBeGreaterThan(0)
+    expect(result.riskMetrics.volatility).toBeGreaterThanOrEqual(0)
+    expect(result.allocation.byAssetClass.length).toBeGreaterThan(0)
+    expect(result.allocation.bySector.length).toBeGreaterThan(0)
+    expect(result.allocation.byGeography.length).toBeGreaterThan(0)
+  })
+
+  it('computes allocation by asset class', () => {
+    const input: AnalyticsInput = {
+      snapshots: makeSnapshots(mockPositions),
+      positions: mockPositions,
+      period: 'ALL',
+    }
+    const result = runAnalytics(input)
+    const classes = result.allocation.byAssetClass.map(a => a.category)
+    expect(classes).toContain('Акции')
+    expect(classes).toContain('Облигации')
+  })
+
+  it('computes allocation by sector', () => {
+    const input: AnalyticsInput = {
+      snapshots: makeSnapshots(mockPositions),
+      positions: mockPositions,
+      period: 'ALL',
+    }
+    const result = runAnalytics(input)
+    const sectors = result.allocation.bySector.map(a => a.category)
+    expect(sectors).toContain('Финансы')
+    expect(sectors).toContain('Гос. облигации')
+  })
+
+  it('includes benchmark when provided', () => {
+    const input: AnalyticsInput = {
+      snapshots: makeSnapshots(mockPositions),
+      positions: mockPositions,
+      benchmarkData: {
+        points: [
+          { date: '2025-01-01', value: 3200 },
+          { date: '2025-02-01', value: 3300 },
+        ],
+        startDate: '2025-01-01',
+        endDate: '2025-02-01',
+        periodReturn: 3.125,
+      },
+      period: 'ALL',
+    }
+    const result = runAnalytics(input)
+    expect(result.benchmark).toBeDefined()
+    expect(result.benchmark!.benchmarkName).toBe('Индекс МосБиржи')
+  })
+
+  it('handles empty positions', () => {
+    const input: AnalyticsInput = {
+      snapshots: [],
+      positions: [],
+      period: 'ALL',
+    }
+    const result = runAnalytics(input)
+    expect(result.allocation.byAssetClass).toHaveLength(0)
+    expect(result.portfolioTimeSeries.points).toHaveLength(0)
+  })
+})

--- a/src/features/analytics/services/__tests__/export-service.test.ts
+++ b/src/features/analytics/services/__tests__/export-service.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { exportToCsv, exportToHtml } from '../export-service'
+import type { GeneratedReport, RiskMetrics } from '../../domain/models'
+
+describe('export-service', () => {
+  const mockMetrics: RiskMetrics = {
+    volatility: 18, sharpeRatio: 1.1, maxDrawdown: 8,
+    maxDrawdownPeriod: { peakDate: '2025-01-01', troughDate: '2025-02-01' },
+  }
+
+  const mockReport: GeneratedReport = {
+    config: { periodType: 'yearly', year: 2025, includeCharts: true, includeTaxBreakdown: false, includeTransactions: false },
+    generatedAt: '2025-12-01T00:00:00Z',
+    metrics: mockMetrics,
+    allocation: [
+      { category: 'Акции', value: 100000, percent: 70, color: '#1976d2' },
+      { category: 'Облигации', value: 42857, percent: 30, color: '#2e7d32' },
+    ],
+    portfolioReturn: 12.5,
+  }
+
+  it('exports CSV with headers', () => {
+    const csv = exportToCsv(mockReport)
+    expect(csv).toContain('Отчёт по портфелю')
+    expect(csv).toContain('Доходность портфеля;12.50%')
+    expect(csv).toContain('Волатильность;18.00%')
+    expect(csv).toContain('Акции;100000.00;70.00')
+    expect(csv).toContain('Облигации;42857.00;30.00')
+  })
+
+  it('includes tax data in CSV when present', () => {
+    const withTax: GeneratedReport = {
+      ...mockReport,
+      taxSummary: {
+        period: { year: 2025 }, dividendIncome: 5000, dividendTax: 650,
+        capitalGains: 3000, capitalGainsTax: 390, taxExemptGains: 0,
+        totalTaxLiability: 1040, transactions: [],
+      },
+    }
+    const csv = exportToCsv(withTax)
+    expect(csv).toContain('Налоговая сводка')
+    expect(csv).toContain('5000.00')
+  })
+
+  it('exports HTML with structure', () => {
+    const html = exportToHtml(mockReport)
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('Отчёт по портфелю')
+    expect(html).toContain('12.50%')
+    expect(html).toContain('Акции')
+    expect(html).toContain('Облигации')
+  })
+
+  it('includes print CSS in HTML', () => {
+    const html = exportToHtml(mockReport)
+    expect(html).toContain('@media print')
+  })
+})

--- a/src/features/analytics/services/__tests__/report-service.test.ts
+++ b/src/features/analytics/services/__tests__/report-service.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { generateReport, getReportTitle } from '../report-service'
+import type { AnalyticsResult, ReportConfig, RiskMetrics } from '../../domain/models'
+
+describe('report-service', () => {
+  const mockMetrics: RiskMetrics = {
+    volatility: 18, sharpeRatio: 1.1, maxDrawdown: 8,
+    maxDrawdownPeriod: { peakDate: '2025-01-01', troughDate: '2025-02-01' },
+  }
+
+  const mockResult: AnalyticsResult = {
+    portfolioTimeSeries: { points: [], startDate: '', endDate: '', periodReturn: 12 },
+    riskMetrics: mockMetrics,
+    allocation: {
+      byAssetClass: [{ category: 'Акции', value: 100000, percent: 70, color: '#1976d2' }],
+      bySector: [],
+      byGeography: [],
+    },
+  }
+
+  it('generates report with config', () => {
+    const config: ReportConfig = {
+      periodType: 'yearly', year: 2025,
+      includeCharts: true, includeTaxBreakdown: false, includeTransactions: false,
+    }
+    const report = generateReport(config, mockResult)
+    expect(report.config).toBe(config)
+    expect(report.metrics).toBe(mockMetrics)
+    expect(report.portfolioReturn).toBe(12)
+    expect(report.taxSummary).toBeUndefined()
+    expect(report.transactions).toBeUndefined()
+  })
+
+  it('includes tax when configured', () => {
+    const config: ReportConfig = {
+      periodType: 'yearly', year: 2025,
+      includeCharts: true, includeTaxBreakdown: true, includeTransactions: true,
+    }
+    const taxReport = {
+      period: { year: 2025 }, dividendIncome: 5000, dividendTax: 650,
+      capitalGains: 3000, capitalGainsTax: 390, taxExemptGains: 0,
+      totalTaxLiability: 1040, transactions: [],
+    }
+    const report = generateReport(config, mockResult, taxReport, [])
+    expect(report.taxSummary).toBeDefined()
+    expect(report.transactions).toBeDefined()
+  })
+
+  it('formats yearly title', () => {
+    expect(getReportTitle({ periodType: 'yearly', year: 2025, includeCharts: true, includeTaxBreakdown: true, includeTransactions: true }))
+      .toBe('2025 год')
+  })
+
+  it('formats monthly title', () => {
+    expect(getReportTitle({ periodType: 'monthly', year: 2025, month: 3, includeCharts: true, includeTaxBreakdown: true, includeTransactions: true }))
+      .toBe('Март 2025')
+  })
+
+  it('formats quarterly title', () => {
+    expect(getReportTitle({ periodType: 'quarterly', year: 2025, quarter: 2, includeCharts: true, includeTaxBreakdown: true, includeTransactions: true }))
+      .toBe('II квартал 2025')
+  })
+})

--- a/src/features/analytics/services/analytics-service.ts
+++ b/src/features/analytics/services/analytics-service.ts
@@ -1,0 +1,139 @@
+import type {
+  AnalyticsInput,
+  AnalyticsResult,
+  AllocationBreakdown,
+  GeographyBreakdown,
+  CorrelationMatrix,
+} from '../domain/models'
+import type { ViewPosition } from '@/features/portfolio-view/domain/models'
+import { ASSET_CLASS_COLORS, SECTOR_COLORS, GEOGRAPHY_REGIONS } from '../domain/constants'
+import { buildTimeSeries } from '../engines/time-series-engine'
+import { computeRiskMetrics, computeCorrelationMatrix } from '../engines/risk-metrics-engine'
+import { compareToBenchmark } from '../engines/benchmark-engine'
+import { dailyReturnsFromSeries } from '../engines/time-series-engine'
+
+const ASSET_CLASS_LABELS: Record<string, string> = {
+  stock: 'Акции',
+  bond: 'Облигации',
+  etf: 'ETF',
+  currency: 'Валюта',
+  other: 'Прочее',
+}
+
+const GEOGRAPHY_MAP: Record<string, string> = {
+  'SBER': 'Россия', 'SBERP': 'Россия', 'LKOH': 'Россия', 'GAZP': 'Россия',
+  'YNDX': 'Россия', 'MGNT': 'Россия', 'GMKN': 'Россия', 'ROSN': 'Россия',
+  'MOEX': 'Россия', 'TMOS': 'Россия', 'TBRU': 'Россия', 'VTBM': 'Россия',
+  'SU26238': 'Россия', 'SU26240': 'Россия', 'RU000A106Y': 'Россия',
+}
+
+export function runAnalytics(input: AnalyticsInput): AnalyticsResult {
+  const portfolioTimeSeries = buildTimeSeries(input.snapshots, input.period)
+  const riskMetrics = computeRiskMetrics(portfolioTimeSeries.points)
+
+  const benchmark = input.benchmarkData
+    ? compareToBenchmark(portfolioTimeSeries, input.benchmarkData)
+    : undefined
+
+  const allocation = computeAllocations(input.positions)
+  const correlationMatrix = computePortfolioCorrelations(input.snapshots, input.positions)
+
+  return {
+    portfolioTimeSeries,
+    riskMetrics,
+    benchmark,
+    allocation,
+    correlationMatrix,
+  }
+}
+
+function computeAllocations(positions: ViewPosition[]): {
+  byAssetClass: AllocationBreakdown[]
+  bySector: AllocationBreakdown[]
+  byGeography: GeographyBreakdown[]
+} {
+  const totalValue = positions.reduce((sum, p) => sum + p.currentValue, 0)
+  if (totalValue === 0) {
+    return { byAssetClass: [], bySector: [], byGeography: [] }
+  }
+
+  const byAssetClass = groupAndSort(
+    positions,
+    p => ASSET_CLASS_LABELS[p.assetClass] ?? p.assetClass,
+    totalValue,
+    ASSET_CLASS_COLORS,
+  )
+
+  const bySector = groupAndSort(
+    positions,
+    p => p.sector,
+    totalValue,
+    SECTOR_COLORS,
+  )
+
+  const geoMap = new Map<string, number>()
+  for (const p of positions) {
+    const region = GEOGRAPHY_MAP[p.ticker] ?? 'Прочее'
+    geoMap.set(region, (geoMap.get(region) ?? 0) + p.currentValue)
+  }
+
+  const byGeography: GeographyBreakdown[] = [...geoMap.entries()]
+    .map(([region, value]) => ({
+      region,
+      value: Math.round(value * 100) / 100,
+      percent: Math.round((value / totalValue) * 10000) / 100,
+    }))
+    .sort((a, b) => b.value - a.value)
+
+  return { byAssetClass, bySector, byGeography }
+}
+
+function groupAndSort(
+  positions: ViewPosition[],
+  keyFn: (p: ViewPosition) => string,
+  totalValue: number,
+  colors: Record<string, string>,
+): AllocationBreakdown[] {
+  const map = new Map<string, number>()
+  for (const p of positions) {
+    const key = keyFn(p)
+    map.set(key, (map.get(key) ?? 0) + p.currentValue)
+  }
+
+  return [...map.entries()]
+    .map(([category, value]) => ({
+      category,
+      value: Math.round(value * 100) / 100,
+      percent: Math.round((value / totalValue) * 10000) / 100,
+      color: colors[category] ?? '#757575',
+    }))
+    .sort((a, b) => b.value - a.value)
+}
+
+function computePortfolioCorrelations(
+  snapshots: PortfolioSnapshot[],
+  positions: ViewPosition[],
+): CorrelationMatrix | undefined {
+  if (snapshots.length < 10) return undefined
+
+  const tickers = [...new Set(positions.map(p => p.ticker))].slice(0, 8)
+  const assetReturns = new Map<string, number[]>()
+
+  for (const ticker of tickers) {
+    const tickerValues = snapshots
+      .map(s => {
+        const pos = s.positions.find(p => p.ticker === ticker)
+        return { date: s.date, value: pos?.currentValue ?? 0 }
+      })
+      .filter(p => p.value > 0)
+
+    if (tickerValues.length >= 10) {
+      assetReturns.set(ticker, dailyReturnsFromSeries(tickerValues))
+    }
+  }
+
+  if (assetReturns.size < 2) return undefined
+  return computeCorrelationMatrix(assetReturns)
+}
+
+type PortfolioSnapshot = import('../domain/models').PortfolioSnapshot

--- a/src/features/analytics/services/demo-data.ts
+++ b/src/features/analytics/services/demo-data.ts
@@ -1,0 +1,149 @@
+import type {
+  PortfolioSnapshot,
+  TimeSeries,
+  TimeSeriesPoint,
+  TaxableTransaction,
+  AnalysisPeriod,
+  AnalyticsResult,
+} from '../domain/models'
+import type { ViewPosition } from '@/features/portfolio-view/domain/models'
+import { getAllPositions } from '@/features/portfolio-view/services/portfolio-service'
+import { runAnalytics } from './analytics-service'
+
+function generateSnapshots(positions: ViewPosition[], days: number): PortfolioSnapshot[] {
+  const snapshots: PortfolioSnapshot[] = []
+  const baseTotal = positions.reduce((s, p) => s + p.costBasis, 0)
+  const currentTotal = positions.reduce((s, p) => s + p.currentValue, 0)
+  const now = new Date()
+
+  for (let i = days; i >= 0; i--) {
+    const date = new Date(now)
+    date.setDate(date.getDate() - i)
+    if (date.getDay() === 0 || date.getDay() === 6) continue
+
+    const progress = (days - i) / days
+    const trend = baseTotal + (currentTotal - baseTotal) * progress
+    const noise = (Math.sin(i * 0.3) * 0.02 + Math.cos(i * 0.7) * 0.015) * trend
+    const totalValue = Math.round((trend + noise) * 100) / 100
+
+    const snapshotPositions = positions.map(p => {
+      const posProgress = p.costBasis + (p.currentValue - p.costBasis) * progress
+      const posNoise = (Math.sin(i * 0.5 + p.ticker.charCodeAt(0)) * 0.03) * posProgress
+      const posValue = Math.max(0, posProgress + posNoise)
+      return {
+        ...p,
+        currentValue: Math.round(posValue * 100) / 100,
+        currentPrice: p.quantity > 0 ? Math.round((posValue / p.quantity) * 100) / 100 : 0,
+      }
+    })
+
+    snapshots.push({
+      date: date.toISOString().split('T')[0]!,
+      totalValue,
+      positions: snapshotPositions,
+    })
+  }
+
+  return snapshots
+}
+
+function generateBenchmarkSeries(days: number): TimeSeries {
+  const points: TimeSeriesPoint[] = []
+  const now = new Date()
+  const baseValue = 3200
+
+  for (let i = days; i >= 0; i--) {
+    const date = new Date(now)
+    date.setDate(date.getDate() - i)
+    if (date.getDay() === 0 || date.getDay() === 6) continue
+
+    const progress = (days - i) / days
+    const trend = baseValue * (1 + 0.12 * progress)
+    const noise = Math.sin(i * 0.4) * 50 + Math.cos(i * 0.9) * 30
+    const value = Math.round((trend + noise) * 100) / 100
+
+    points.push({
+      date: date.toISOString().split('T')[0]!,
+      value,
+    })
+  }
+
+  if (points.length < 2) {
+    return { points, startDate: '', endDate: '', periodReturn: 0 }
+  }
+
+  const firstVal = points[0]!.value
+  const lastVal = points[points.length - 1]!.value
+  const periodReturn = firstVal > 0 ? ((lastVal - firstVal) / firstVal) * 100 : 0
+
+  return {
+    points,
+    startDate: points[0]!.date,
+    endDate: points[points.length - 1]!.date,
+    periodReturn: Math.round(periodReturn * 100) / 100,
+  }
+}
+
+function generateTaxTransactions(): TaxableTransaction[] {
+  return [
+    {
+      date: '2025-03-15', ticker: 'SBER', type: 'dividend',
+      amount: 18500, taxAmount: 2405, isExempt: false,
+    },
+    {
+      date: '2025-06-20', ticker: 'LKOH', type: 'dividend',
+      amount: 6300, taxAmount: 819, isExempt: false,
+    },
+    {
+      date: '2025-04-10', ticker: 'GAZP', type: 'sale',
+      amount: 4200, taxAmount: 546, isExempt: false,
+    },
+    {
+      date: '2025-07-01', ticker: 'GMKN', type: 'dividend',
+      amount: 3800, taxAmount: 494, isExempt: false,
+    },
+    {
+      date: '2025-09-15', ticker: 'ROSN', type: 'dividend',
+      amount: 5100, taxAmount: 663, isExempt: false,
+    },
+    {
+      date: '2025-05-22', ticker: 'MOEX', type: 'sale',
+      amount: 2800, taxAmount: 0, isExempt: true, exemptReason: '3+ года владения',
+    },
+    {
+      date: '2025-08-12', ticker: 'MGNT', type: 'dividend',
+      amount: 2400, taxAmount: 312, isExempt: false,
+    },
+    {
+      date: '2025-11-05', ticker: 'SBERP', type: 'dividend',
+      amount: 7000, taxAmount: 910, isExempt: false,
+    },
+  ]
+}
+
+export function getDemoAnalytics(period: AnalysisPeriod): AnalyticsResult {
+  const positions = getAllPositions()
+  const snapshots = generateSnapshots(positions, 365)
+  const benchmarkData = generateBenchmarkSeries(365)
+  const transactions = generateTaxTransactions()
+
+  return runAnalytics({
+    snapshots,
+    positions,
+    benchmarkData,
+    transactions,
+    period,
+  })
+}
+
+export function getDemoSnapshots(): PortfolioSnapshot[] {
+  return generateSnapshots(getAllPositions(), 365)
+}
+
+export function getDemoBenchmarkSeries(): TimeSeries {
+  return generateBenchmarkSeries(365)
+}
+
+export function getDemoTaxTransactions(): TaxableTransaction[] {
+  return generateTaxTransactions()
+}

--- a/src/features/analytics/services/export-service.ts
+++ b/src/features/analytics/services/export-service.ts
@@ -1,0 +1,115 @@
+import type { GeneratedReport } from '../domain/models'
+import { getReportTitle } from './report-service'
+
+export function exportToCsv(report: GeneratedReport): string {
+  const lines: string[] = []
+  const title = getReportTitle(report.config)
+
+  lines.push(`Отчёт по портфелю;${title}`)
+  lines.push(`Дата генерации;${new Date(report.generatedAt).toLocaleDateString('ru-RU')}`)
+  lines.push('')
+  lines.push('Показатель;Значение')
+  lines.push(`Доходность портфеля;${report.portfolioReturn.toFixed(2)}%`)
+  if (report.benchmarkReturn !== undefined) {
+    lines.push(`Доходность бенчмарка;${report.benchmarkReturn.toFixed(2)}%`)
+  }
+  lines.push(`Волатильность;${report.metrics.volatility.toFixed(2)}%`)
+  lines.push(`Коэффициент Шарпа;${report.metrics.sharpeRatio.toFixed(2)}`)
+  lines.push(`Макс. просадка;${report.metrics.maxDrawdown.toFixed(2)}%`)
+
+  lines.push('')
+  lines.push('Распределение активов')
+  lines.push('Категория;Стоимость (₽);Доля (%)')
+  for (const a of report.allocation) {
+    lines.push(`${a.category};${a.value.toFixed(2)};${a.percent.toFixed(2)}`)
+  }
+
+  if (report.taxSummary) {
+    lines.push('')
+    lines.push('Налоговая сводка')
+    lines.push(`Дивидендный доход;${report.taxSummary.dividendIncome.toFixed(2)}`)
+    lines.push(`Налог на дивиденды;${report.taxSummary.dividendTax.toFixed(2)}`)
+    lines.push(`Прирост капитала;${report.taxSummary.capitalGains.toFixed(2)}`)
+    lines.push(`Налог на прирост;${report.taxSummary.capitalGainsTax.toFixed(2)}`)
+    lines.push(`Льготные доходы;${report.taxSummary.taxExemptGains.toFixed(2)}`)
+    lines.push(`Итого налогов;${report.taxSummary.totalTaxLiability.toFixed(2)}`)
+  }
+
+  if (report.transactions && report.transactions.length > 0) {
+    lines.push('')
+    lines.push('Операции')
+    lines.push('Дата;Тикер;Тип;Сумма;Налог;Льгота')
+    for (const t of report.transactions) {
+      const typeLabel = t.type === 'dividend' ? 'Дивиденды' : 'Продажа'
+      const exemptLabel = t.isExempt ? 'Да' : 'Нет'
+      lines.push(`${t.date};${t.ticker};${typeLabel};${t.amount.toFixed(2)};${t.taxAmount.toFixed(2)};${exemptLabel}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+export function exportToHtml(report: GeneratedReport): string {
+  const title = getReportTitle(report.config)
+
+  let html = `<!DOCTYPE html>
+<html lang="ru">
+<head><meta charset="utf-8"><title>Отчёт: ${title}</title>
+<style>
+body{font-family:Arial,sans-serif;max-width:800px;margin:0 auto;padding:20px;color:#333}
+h1{color:#1976d2;border-bottom:2px solid #1976d2;padding-bottom:8px}
+h2{color:#555;margin-top:24px}
+table{width:100%;border-collapse:collapse;margin:12px 0}
+th,td{padding:8px 12px;text-align:left;border-bottom:1px solid #e0e0e0}
+th{background:#f5f5f5;font-weight:600}
+.positive{color:#2e7d32}.negative{color:#f44336}
+.metric-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin:12px 0}
+.metric-card{padding:12px;border:1px solid #e0e0e0;border-radius:8px}
+.metric-value{font-size:1.3em;font-weight:700}
+.metric-label{font-size:0.85em;color:#999}
+@media print{body{padding:0}h1{page-break-before:avoid}}
+</style></head><body>
+<h1>Отчёт по портфелю — ${title}</h1>
+<p>Дата: ${new Date(report.generatedAt).toLocaleDateString('ru-RU')}</p>`
+
+  html += `<h2>Ключевые показатели</h2>
+<div class="metric-grid">
+<div class="metric-card"><div class="metric-label">Доходность</div><div class="metric-value ${report.portfolioReturn >= 0 ? 'positive' : 'negative'}">${report.portfolioReturn.toFixed(2)}%</div></div>
+<div class="metric-card"><div class="metric-label">Волатильность</div><div class="metric-value">${report.metrics.volatility.toFixed(2)}%</div></div>
+<div class="metric-card"><div class="metric-label">Коэфф. Шарпа</div><div class="metric-value">${report.metrics.sharpeRatio.toFixed(2)}</div></div>
+<div class="metric-card"><div class="metric-label">Макс. просадка</div><div class="metric-value negative">${report.metrics.maxDrawdown.toFixed(2)}%</div></div>
+</div>`
+
+  html += `<h2>Распределение активов</h2>
+<table><thead><tr><th>Категория</th><th>Стоимость (₽)</th><th>Доля</th></tr></thead><tbody>`
+  for (const a of report.allocation) {
+    html += `<tr><td>${a.category}</td><td>${a.value.toLocaleString('ru-RU')}</td><td>${a.percent.toFixed(1)}%</td></tr>`
+  }
+  html += '</tbody></table>'
+
+  if (report.taxSummary) {
+    html += `<h2>Налоги</h2>
+<table><thead><tr><th>Показатель</th><th>Сумма (₽)</th></tr></thead><tbody>
+<tr><td>Дивидендный доход</td><td>${report.taxSummary.dividendIncome.toLocaleString('ru-RU')}</td></tr>
+<tr><td>Налог на дивиденды</td><td>${report.taxSummary.dividendTax.toLocaleString('ru-RU')}</td></tr>
+<tr><td>Прирост капитала</td><td>${report.taxSummary.capitalGains.toLocaleString('ru-RU')}</td></tr>
+<tr><td>Налог на прирост</td><td>${report.taxSummary.capitalGainsTax.toLocaleString('ru-RU')}</td></tr>
+<tr><td><strong>Итого налогов</strong></td><td><strong>${report.taxSummary.totalTaxLiability.toLocaleString('ru-RU')}</strong></td></tr>
+</tbody></table>`
+  }
+
+  html += '</body></html>'
+  return html
+}
+
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/src/features/analytics/services/report-service.ts
+++ b/src/features/analytics/services/report-service.ts
@@ -1,0 +1,42 @@
+import type {
+  ReportConfig,
+  GeneratedReport,
+  AnalyticsResult,
+  TaxReport,
+  TaxableTransaction,
+} from '../domain/models'
+
+export function generateReport(
+  config: ReportConfig,
+  analyticsResult: AnalyticsResult,
+  taxReport?: TaxReport,
+  transactions?: TaxableTransaction[],
+): GeneratedReport {
+  return {
+    config,
+    generatedAt: new Date().toISOString(),
+    metrics: analyticsResult.riskMetrics,
+    allocation: analyticsResult.allocation.byAssetClass,
+    portfolioReturn: analyticsResult.portfolioTimeSeries.periodReturn,
+    benchmarkReturn: analyticsResult.benchmark?.benchmarkReturn,
+    taxSummary: config.includeTaxBreakdown ? taxReport : undefined,
+    transactions: config.includeTransactions ? transactions : undefined,
+  }
+}
+
+export function getReportTitle(config: ReportConfig): string {
+  const monthNames = [
+    'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
+    'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь',
+  ]
+  const quarterNames = ['I квартал', 'II квартал', 'III квартал', 'IV квартал']
+
+  switch (config.periodType) {
+    case 'monthly':
+      return `${monthNames[(config.month ?? 1) - 1]} ${config.year}`
+    case 'quarterly':
+      return `${quarterNames[(config.quarter ?? 1) - 1]} ${config.year}`
+    case 'yearly':
+      return `${config.year} год`
+  }
+}

--- a/src/features/analytics/ui/AllocationPieChart.tsx
+++ b/src/features/analytics/ui/AllocationPieChart.tsx
@@ -1,0 +1,43 @@
+import type { AllocationBreakdown } from '../domain/models'
+
+interface AllocationPieChartProps {
+  data: AllocationBreakdown[]
+  title: string
+}
+
+export function AllocationPieChart({ data, title }: AllocationPieChartProps) {
+  if (data.length === 0) {
+    return <div className="chart-empty">Нет данных</div>
+  }
+
+  const gradientStops: string[] = []
+  let accumulated = 0
+  for (const item of data) {
+    const start = accumulated
+    accumulated += item.percent
+    gradientStops.push(`${item.color} ${start}% ${accumulated}%`)
+  }
+
+  const pieStyle = {
+    background: `conic-gradient(${gradientStops.join(', ')})`,
+  }
+
+  return (
+    <div className="pie-chart-section">
+      <h4 className="pie-chart-title">{title}</h4>
+      <div className="pie-chart-layout">
+        <div className="pie-chart" style={pieStyle} />
+        <div className="pie-legend">
+          {data.map(item => (
+            <div key={item.category} className="pie-legend-item">
+              <span className="pie-legend-dot" style={{ backgroundColor: item.color }} />
+              <span className="pie-legend-label">{item.category}</span>
+              <span className="pie-legend-value">{item.percent.toFixed(1)}%</span>
+              <span className="pie-legend-amount">{item.value.toLocaleString('ru-RU')} ₽</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/AnalyticsPage.css
+++ b/src/features/analytics/ui/AnalyticsPage.css
@@ -1,0 +1,799 @@
+.analytics-page {
+  padding: 1.25rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.analytics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.analytics-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #333;
+}
+
+/* Period Selector */
+.period-selector {
+  display: flex;
+  gap: 0.25rem;
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 0.25rem;
+}
+
+.period-btn {
+  padding: 0.4rem 0.75rem;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.period-btn:hover {
+  background: #e0e0e0;
+}
+
+.period-btn.active {
+  background: #1976d2;
+  color: #fff;
+}
+
+/* Tabs */
+.analytics-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 2px solid #e0e0e0;
+  margin-bottom: 1.25rem;
+}
+
+.analytics-tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #666;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: all 0.2s;
+}
+
+.analytics-tab:hover {
+  color: #333;
+}
+
+.analytics-tab.active {
+  color: #1976d2;
+  border-bottom-color: #1976d2;
+}
+
+/* Overview Cards */
+.overview-cards {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.overview-card {
+  flex: 1;
+  min-width: 160px;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.overview-card-label {
+  font-size: 0.75rem;
+  color: #999;
+  margin-bottom: 0.25rem;
+}
+
+.overview-card-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.overview-allocations {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.overview-allocations > * {
+  flex: 1;
+  min-width: 280px;
+}
+
+/* Chart Containers */
+.chart-container {
+  width: 100%;
+  margin: 0.75rem 0;
+}
+
+.chart-container svg {
+  width: 100%;
+  height: auto;
+}
+
+.chart-empty {
+  padding: 2rem;
+  text-align: center;
+  color: #999;
+  font-style: italic;
+}
+
+.chart-section {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.chart-section h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.chart-section-row {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.chart-section-row > * {
+  flex: 1;
+  min-width: 280px;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+/* Pie Chart */
+.pie-chart-section {
+  margin-bottom: 1rem;
+}
+
+.pie-chart-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.pie-chart-layout {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.pie-chart {
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pie-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.pie-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.pie-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pie-legend-label {
+  min-width: 80px;
+  color: #333;
+}
+
+.pie-legend-value {
+  font-weight: 600;
+  min-width: 45px;
+  text-align: right;
+}
+
+.pie-legend-amount {
+  color: #999;
+  font-size: 0.8rem;
+}
+
+/* Benchmark */
+.benchmark-section {
+  margin-bottom: 1rem;
+}
+
+.benchmark-stats {
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.benchmark-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.benchmark-stat-label {
+  font-size: 0.75rem;
+  color: #999;
+}
+
+.benchmark-stat-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.benchmark-legend {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-line {
+  width: 20px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.legend-line-dashed {
+  background: repeating-linear-gradient(
+    to right,
+    currentColor 0 6px,
+    transparent 6px 9px
+  ) !important;
+}
+
+/* Geography */
+.geography-section {
+  margin-bottom: 1rem;
+}
+
+.geography-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.geography-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.geography-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.geography-label {
+  width: 70px;
+  font-size: 0.85rem;
+  color: #333;
+  flex-shrink: 0;
+}
+
+.geography-bar-track {
+  flex: 1;
+  height: 20px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.geography-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.geography-value {
+  width: 50px;
+  text-align: right;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.geography-amount {
+  width: 90px;
+  text-align: right;
+  color: #999;
+  font-size: 0.8rem;
+}
+
+/* Risk Metrics */
+.risk-metrics-panel {
+  margin-bottom: 1.25rem;
+}
+
+.risk-metrics-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.risk-cards {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.risk-card {
+  flex: 1;
+  min-width: 160px;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.risk-card-label {
+  font-size: 0.75rem;
+  color: #999;
+  margin-bottom: 0.25rem;
+}
+
+.risk-card-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.risk-card-desc {
+  font-size: 0.75rem;
+  color: #999;
+  margin-top: 0.25rem;
+}
+
+/* Correlation Matrix */
+.correlation-section {
+  margin-bottom: 1.25rem;
+}
+
+.correlation-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.correlation-grid {
+  display: grid;
+  gap: 2px;
+  max-width: 600px;
+}
+
+.correlation-corner {
+  background: transparent;
+}
+
+.correlation-header {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #333;
+  padding: 0.25rem;
+}
+
+.correlation-row-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #333;
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem;
+}
+
+.correlation-cell {
+  text-align: center;
+  padding: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 4px;
+}
+
+.correlation-legend {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+}
+
+.correlation-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.correlation-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+/* Report Builder */
+.report-builder-section {
+  margin-bottom: 1.25rem;
+}
+
+.report-builder-title {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.report-config {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+  margin-bottom: 1rem;
+}
+
+.config-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.config-label {
+  width: 80px;
+  font-size: 0.85rem;
+  color: #666;
+  flex-shrink: 0;
+}
+
+.config-buttons {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.config-btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #e0e0e0;
+  background: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.config-btn:hover {
+  border-color: #1976d2;
+  color: #1976d2;
+}
+
+.config-btn.active {
+  background: #1976d2;
+  color: #fff;
+  border-color: #1976d2;
+}
+
+.config-select {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #333;
+  background: #fff;
+}
+
+.config-checkboxes {
+  flex-wrap: wrap;
+}
+
+.config-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #666;
+  cursor: pointer;
+}
+
+.report-generate-btn {
+  padding: 0.6rem 1.5rem;
+  background: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+
+.report-generate-btn:hover {
+  background: #1565c0;
+}
+
+.report-preview {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.report-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.report-preview-header h5 {
+  margin: 0;
+  font-size: 1rem;
+  color: #333;
+}
+
+.report-export-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.export-btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #1976d2;
+  background: #fff;
+  color: #1976d2;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s;
+}
+
+.export-btn:hover {
+  background: #1976d2;
+  color: #fff;
+}
+
+.report-preview-summary {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.report-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.report-metric-label {
+  font-size: 0.75rem;
+  color: #999;
+}
+
+.report-metric-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #333;
+}
+
+/* Tax Summary */
+.tax-summary-section {
+  margin-bottom: 1.25rem;
+}
+
+.tax-summary-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: #333;
+}
+
+.tax-cards {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.tax-card {
+  flex: 1;
+  min-width: 160px;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.tax-card-total {
+  border-color: #1976d2;
+  background: #e3f2fd;
+}
+
+.tax-card-label {
+  font-size: 0.75rem;
+  color: #999;
+  margin-bottom: 0.25rem;
+}
+
+.tax-card-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.tax-card-tax {
+  font-size: 0.75rem;
+  color: #f44336;
+  margin-top: 0.25rem;
+}
+
+.tax-transactions h5 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.tax-table,
+.transaction-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tax-table th,
+.tax-table td,
+.transaction-table th,
+.transaction-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 0.85rem;
+}
+
+.tax-table th,
+.transaction-table th {
+  background: #f5f5f5;
+  font-weight: 600;
+  color: #666;
+}
+
+.tx-ticker {
+  font-weight: 600;
+  color: #1976d2;
+}
+
+.tx-type-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.tx-type-badge.dividend {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.tx-type-badge.sale {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.tax-exempt-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: #e8f5e9;
+  color: #2e7d32;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.tax-paid-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  background: #fce4ec;
+  color: #c62828;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+/* Transaction History */
+.transaction-history-section {
+  margin-bottom: 1.25rem;
+}
+
+.transaction-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.transaction-title {
+  margin: 0;
+  font-size: 1rem;
+  color: #333;
+}
+
+.transaction-filters {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.filter-btn {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #e0e0e0;
+  background: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.filter-btn:hover {
+  border-color: #1976d2;
+}
+
+.filter-btn.active {
+  background: #1976d2;
+  color: #fff;
+  border-color: #1976d2;
+}
+
+.transaction-summary {
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+/* Color utilities */
+.positive {
+  color: #2e7d32;
+}
+
+.negative {
+  color: #f44336;
+}

--- a/src/features/analytics/ui/AnalyticsPage.tsx
+++ b/src/features/analytics/ui/AnalyticsPage.tsx
@@ -1,0 +1,148 @@
+import { useState, useMemo } from 'react'
+import type { AnalysisPeriod, ReportConfig, GeneratedReport } from '../domain/models'
+import { getDemoAnalytics, getDemoTaxTransactions } from '../services/demo-data'
+import { computeTaxReport } from '../engines/tax-engine'
+import { generateReport } from '../services/report-service'
+import { PeriodSelector } from './PeriodSelector'
+import { PortfolioValueChart } from './PortfolioValueChart'
+import { AllocationPieChart } from './AllocationPieChart'
+import { BenchmarkComparison } from './BenchmarkComparison'
+import { GeographyBreakdown } from './GeographyBreakdown'
+import { RiskMetricsPanel } from './RiskMetricsPanel'
+import { CorrelationMatrix } from './CorrelationMatrix'
+import { ReportBuilder } from './ReportBuilder'
+import { TaxSummary } from './TaxSummary'
+import { TransactionHistory } from './TransactionHistory'
+import './AnalyticsPage.css'
+
+type AnalyticsTab = 'overview' | 'charts' | 'metrics' | 'reports' | 'tax'
+
+const TAB_LABELS: Record<AnalyticsTab, string> = {
+  overview: 'Обзор',
+  charts: 'Графики',
+  metrics: 'Метрики',
+  reports: 'Отчёты',
+  tax: 'Налоги',
+}
+
+export function AnalyticsPage() {
+  const [tab, setTab] = useState<AnalyticsTab>('overview')
+  const [period, setPeriod] = useState<AnalysisPeriod>('1Y')
+
+  const analytics = useMemo(() => getDemoAnalytics(period), [period])
+  const taxTransactions = useMemo(() => getDemoTaxTransactions(), [])
+  const taxReport = useMemo(
+    () => computeTaxReport(taxTransactions, { year: 2025 }),
+    [taxTransactions],
+  )
+
+  const totalValue = analytics.portfolioTimeSeries.points.length > 0
+    ? analytics.portfolioTimeSeries.points[analytics.portfolioTimeSeries.points.length - 1]!.value
+    : 0
+
+  function handleGenerateReport(config: ReportConfig): GeneratedReport | null {
+    return generateReport(config, analytics, taxReport, taxTransactions)
+  }
+
+  const tabs: AnalyticsTab[] = ['overview', 'charts', 'metrics', 'reports', 'tax']
+
+  return (
+    <div className="analytics-page">
+      <div className="analytics-header">
+        <h2>Аналитика</h2>
+        <PeriodSelector selected={period} onChange={setPeriod} />
+      </div>
+
+      <div className="analytics-tabs">
+        {tabs.map(t => (
+          <button
+            key={t}
+            className={`analytics-tab ${tab === t ? 'active' : ''}`}
+            onClick={() => setTab(t)}
+          >
+            {TAB_LABELS[t]}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'overview' && (
+        <div className="analytics-overview">
+          <div className="overview-cards">
+            <div className="overview-card">
+              <div className="overview-card-label">Стоимость портфеля</div>
+              <div className="overview-card-value">{totalValue.toLocaleString('ru-RU')} ₽</div>
+            </div>
+            <div className="overview-card">
+              <div className="overview-card-label">Доходность</div>
+              <div className={`overview-card-value ${analytics.portfolioTimeSeries.periodReturn >= 0 ? 'positive' : 'negative'}`}>
+                {analytics.portfolioTimeSeries.periodReturn >= 0 ? '+' : ''}{analytics.portfolioTimeSeries.periodReturn.toFixed(2)}%
+              </div>
+            </div>
+            <div className="overview-card">
+              <div className="overview-card-label">Волатильность</div>
+              <div className="overview-card-value">{analytics.riskMetrics.volatility.toFixed(2)}%</div>
+            </div>
+            <div className="overview-card">
+              <div className="overview-card-label">Коэфф. Шарпа</div>
+              <div className="overview-card-value">{analytics.riskMetrics.sharpeRatio.toFixed(2)}</div>
+            </div>
+          </div>
+
+          <PortfolioValueChart series={analytics.portfolioTimeSeries} />
+
+          <div className="overview-allocations">
+            <AllocationPieChart data={analytics.allocation.byAssetClass} title="По типу актива" />
+            <AllocationPieChart data={analytics.allocation.bySector} title="По секторам" />
+          </div>
+        </div>
+      )}
+
+      {tab === 'charts' && (
+        <div className="analytics-charts">
+          <div className="chart-section">
+            <h3>Стоимость портфеля</h3>
+            <PortfolioValueChart series={analytics.portfolioTimeSeries} />
+          </div>
+
+          {analytics.benchmark && (
+            <div className="chart-section">
+              <h3>Сравнение с бенчмарком</h3>
+              <BenchmarkComparison comparison={analytics.benchmark} />
+            </div>
+          )}
+
+          <div className="chart-section">
+            <GeographyBreakdown data={analytics.allocation.byGeography} />
+          </div>
+
+          <div className="chart-section-row">
+            <AllocationPieChart data={analytics.allocation.byAssetClass} title="Типы активов" />
+            <AllocationPieChart data={analytics.allocation.bySector} title="Секторы" />
+          </div>
+        </div>
+      )}
+
+      {tab === 'metrics' && (
+        <div className="analytics-metrics">
+          <RiskMetricsPanel metrics={analytics.riskMetrics} />
+          {analytics.correlationMatrix && (
+            <CorrelationMatrix matrix={analytics.correlationMatrix} />
+          )}
+        </div>
+      )}
+
+      {tab === 'reports' && (
+        <div className="analytics-reports">
+          <ReportBuilder onGenerate={handleGenerateReport} />
+        </div>
+      )}
+
+      {tab === 'tax' && (
+        <div className="analytics-tax">
+          <TaxSummary report={taxReport} />
+          <TransactionHistory transactions={taxTransactions} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/analytics/ui/BenchmarkComparison.tsx
+++ b/src/features/analytics/ui/BenchmarkComparison.tsx
@@ -1,0 +1,88 @@
+import type { BenchmarkComparison as BenchmarkComparisonType } from '../domain/models'
+
+interface BenchmarkComparisonProps {
+  comparison: BenchmarkComparisonType
+}
+
+export function BenchmarkComparison({ comparison }: BenchmarkComparisonProps) {
+  const { portfolioSeries, benchmarkSeries } = comparison
+
+  if (portfolioSeries.points.length < 2 || benchmarkSeries.points.length < 2) {
+    return <div className="chart-empty">Недостаточно данных для сравнения</div>
+  }
+
+  const width = 700
+  const height = 300
+  const padding = { top: 20, right: 20, bottom: 40, left: 50 }
+  const chartW = width - padding.left - padding.right
+  const chartH = height - padding.top - padding.bottom
+
+  const allValues = [...portfolioSeries.points.map(p => p.value), ...benchmarkSeries.points.map(p => p.value)]
+  const minVal = Math.min(...allValues) * 0.98
+  const maxVal = Math.max(...allValues) * 1.02
+  const valueRange = maxVal - minVal || 1
+
+  const maxLen = Math.max(portfolioSeries.points.length, benchmarkSeries.points.length)
+  const scaleX = (i: number, total: number) => padding.left + (i / (total - 1)) * chartW
+  const scaleY = (v: number) => padding.top + chartH - ((v - minVal) / valueRange) * chartH
+
+  const portfolioLine = portfolioSeries.points
+    .map((p, i) => `${scaleX(i, portfolioSeries.points.length)},${scaleY(p.value)}`)
+    .join(' ')
+
+  const benchmarkLine = benchmarkSeries.points
+    .map((p, i) => `${scaleX(i, benchmarkSeries.points.length)},${scaleY(p.value)}`)
+    .join(' ')
+
+  const yTicks = 5
+  const yLabels = Array.from({ length: yTicks }, (_, i) => {
+    const val = minVal + (valueRange * i) / (yTicks - 1)
+    return { value: val, y: scaleY(val) }
+  })
+
+  const alphaClass = comparison.alpha >= 0 ? 'positive' : 'negative'
+  const alphaSign = comparison.alpha >= 0 ? '+' : ''
+
+  return (
+    <div className="benchmark-section">
+      <div className="benchmark-stats">
+        <div className="benchmark-stat">
+          <span className="benchmark-stat-label">Портфель</span>
+          <span className={`benchmark-stat-value ${comparison.portfolioReturn >= 0 ? 'positive' : 'negative'}`}>
+            {comparison.portfolioReturn >= 0 ? '+' : ''}{comparison.portfolioReturn.toFixed(2)}%
+          </span>
+        </div>
+        <div className="benchmark-stat">
+          <span className="benchmark-stat-label">{comparison.benchmarkName}</span>
+          <span className={`benchmark-stat-value ${comparison.benchmarkReturn >= 0 ? 'positive' : 'negative'}`}>
+            {comparison.benchmarkReturn >= 0 ? '+' : ''}{comparison.benchmarkReturn.toFixed(2)}%
+          </span>
+        </div>
+        <div className="benchmark-stat">
+          <span className="benchmark-stat-label">Альфа</span>
+          <span className={`benchmark-stat-value ${alphaClass}`}>
+            {alphaSign}{comparison.alpha.toFixed(2)}%
+          </span>
+        </div>
+      </div>
+      <div className="chart-container">
+        <svg viewBox={`0 0 ${width} ${height}`} className="benchmark-chart">
+          {yLabels.map((tick, i) => (
+            <g key={i}>
+              <line x1={padding.left} y1={tick.y} x2={width - padding.right} y2={tick.y} stroke="#e0e0e0" strokeWidth="1" />
+              <text x={padding.left - 8} y={tick.y + 4} textAnchor="end" fontSize="11" fill="#999">
+                {tick.value.toFixed(0)}
+              </text>
+            </g>
+          ))}
+          <polyline points={benchmarkLine} fill="none" stroke="#ff9800" strokeWidth="2" strokeDasharray="6 3" />
+          <polyline points={portfolioLine} fill="none" stroke="#1976d2" strokeWidth="2" />
+        </svg>
+      </div>
+      <div className="benchmark-legend">
+        <span className="legend-item"><span className="legend-line" style={{ backgroundColor: '#1976d2' }} /> Портфель</span>
+        <span className="legend-item"><span className="legend-line legend-line-dashed" style={{ backgroundColor: '#ff9800' }} /> {comparison.benchmarkName}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/CorrelationMatrix.tsx
+++ b/src/features/analytics/ui/CorrelationMatrix.tsx
@@ -1,0 +1,73 @@
+import type { CorrelationMatrix as CorrelationMatrixType } from '../domain/models'
+
+interface CorrelationMatrixProps {
+  matrix: CorrelationMatrixType
+}
+
+function getCorrelationColor(value: number): string {
+  if (value >= 0.7) return '#1b5e20'
+  if (value >= 0.3) return '#66bb6a'
+  if (value >= -0.3) return '#e0e0e0'
+  if (value >= -0.7) return '#ef5350'
+  return '#b71c1c'
+}
+
+function getTextColor(value: number): string {
+  if (Math.abs(value) >= 0.7) return '#fff'
+  if (Math.abs(value) >= 0.3) return '#333'
+  return '#333'
+}
+
+export function CorrelationMatrix({ matrix }: CorrelationMatrixProps) {
+  if (matrix.tickers.length === 0) {
+    return <div className="chart-empty">Недостаточно данных для корреляций</div>
+  }
+
+  return (
+    <div className="correlation-section">
+      <h4 className="correlation-title">Корреляционная матрица</h4>
+      <div className="correlation-grid" style={{
+        gridTemplateColumns: `60px repeat(${matrix.tickers.length}, 1fr)`,
+      }}>
+        <div className="correlation-corner" />
+        {matrix.tickers.map(t => (
+          <div key={`h-${t}`} className="correlation-header">{t}</div>
+        ))}
+        {matrix.tickers.map((rowTicker, i) => (
+          <>
+            <div key={`r-${rowTicker}`} className="correlation-row-label">{rowTicker}</div>
+            {matrix.values[i]!.map((val, j) => (
+              <div
+                key={`${i}-${j}`}
+                className="correlation-cell"
+                style={{
+                  backgroundColor: getCorrelationColor(val),
+                  color: getTextColor(val),
+                }}
+              >
+                {val.toFixed(2)}
+              </div>
+            ))}
+          </>
+        ))}
+      </div>
+      <div className="correlation-legend">
+        <span className="correlation-legend-item">
+          <span className="correlation-dot" style={{ backgroundColor: '#1b5e20' }} /> Сильная +
+        </span>
+        <span className="correlation-legend-item">
+          <span className="correlation-dot" style={{ backgroundColor: '#66bb6a' }} /> Слабая +
+        </span>
+        <span className="correlation-legend-item">
+          <span className="correlation-dot" style={{ backgroundColor: '#e0e0e0' }} /> Нейтральная
+        </span>
+        <span className="correlation-legend-item">
+          <span className="correlation-dot" style={{ backgroundColor: '#ef5350' }} /> Слабая −
+        </span>
+        <span className="correlation-legend-item">
+          <span className="correlation-dot" style={{ backgroundColor: '#b71c1c' }} /> Сильная −
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/GeographyBreakdown.tsx
+++ b/src/features/analytics/ui/GeographyBreakdown.tsx
@@ -1,0 +1,38 @@
+import type { GeographyBreakdown as GeographyBreakdownType } from '../domain/models'
+import { GEOGRAPHY_REGIONS } from '../domain/constants'
+
+interface GeographyBreakdownProps {
+  data: GeographyBreakdownType[]
+}
+
+export function GeographyBreakdown({ data }: GeographyBreakdownProps) {
+  if (data.length === 0) {
+    return <div className="chart-empty">Нет данных</div>
+  }
+
+  const maxPercent = Math.max(...data.map(d => d.percent))
+
+  return (
+    <div className="geography-section">
+      <h4 className="geography-title">Географическое распределение</h4>
+      <div className="geography-bars">
+        {data.map(item => (
+          <div key={item.region} className="geography-bar-row">
+            <span className="geography-label">{item.region}</span>
+            <div className="geography-bar-track">
+              <div
+                className="geography-bar-fill"
+                style={{
+                  width: `${(item.percent / maxPercent) * 100}%`,
+                  backgroundColor: GEOGRAPHY_REGIONS[item.region] ?? '#757575',
+                }}
+              />
+            </div>
+            <span className="geography-value">{item.percent.toFixed(1)}%</span>
+            <span className="geography-amount">{item.value.toLocaleString('ru-RU')} ₽</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/PeriodSelector.tsx
+++ b/src/features/analytics/ui/PeriodSelector.tsx
@@ -1,0 +1,25 @@
+import type { AnalysisPeriod } from '../domain/models'
+import { ANALYSIS_PERIODS } from '../domain/constants'
+
+interface PeriodSelectorProps {
+  selected: AnalysisPeriod
+  onChange: (period: AnalysisPeriod) => void
+}
+
+const PERIODS: AnalysisPeriod[] = ['1M', '3M', '6M', '1Y', 'YTD', 'ALL']
+
+export function PeriodSelector({ selected, onChange }: PeriodSelectorProps) {
+  return (
+    <div className="period-selector">
+      {PERIODS.map(p => (
+        <button
+          key={p}
+          className={`period-btn ${selected === p ? 'active' : ''}`}
+          onClick={() => onChange(p)}
+        >
+          {ANALYSIS_PERIODS[p].label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/features/analytics/ui/PortfolioValueChart.tsx
+++ b/src/features/analytics/ui/PortfolioValueChart.tsx
@@ -1,0 +1,104 @@
+import type { TimeSeries } from '../domain/models'
+import { useState } from 'react'
+
+interface PortfolioValueChartProps {
+  series: TimeSeries
+}
+
+export function PortfolioValueChart({ series }: PortfolioValueChartProps) {
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; date: string; value: number } | null>(null)
+
+  if (series.points.length < 2) {
+    return <div className="chart-empty">Недостаточно данных для графика</div>
+  }
+
+  const width = 700
+  const height = 300
+  const padding = { top: 20, right: 20, bottom: 40, left: 70 }
+  const chartW = width - padding.left - padding.right
+  const chartH = height - padding.top - padding.bottom
+
+  const values = series.points.map(p => p.value)
+  const minVal = Math.min(...values) * 0.98
+  const maxVal = Math.max(...values) * 1.02
+  const valueRange = maxVal - minVal || 1
+
+  const scaleX = (i: number) => padding.left + (i / (series.points.length - 1)) * chartW
+  const scaleY = (v: number) => padding.top + chartH - ((v - minVal) / valueRange) * chartH
+
+  const polylinePoints = series.points.map((p, i) => `${scaleX(i)},${scaleY(p.value)}`).join(' ')
+
+  const gradientPoints = [
+    `${scaleX(0)},${padding.top + chartH}`,
+    ...series.points.map((p, i) => `${scaleX(i)},${scaleY(p.value)}`),
+    `${scaleX(series.points.length - 1)},${padding.top + chartH}`,
+  ].join(' ')
+
+  const yTicks = 5
+  const yLabels = Array.from({ length: yTicks }, (_, i) => {
+    const val = minVal + (valueRange * i) / (yTicks - 1)
+    return { value: val, y: scaleY(val) }
+  })
+
+  const xLabelCount = Math.min(6, series.points.length)
+  const xStep = Math.max(1, Math.floor(series.points.length / xLabelCount))
+  const xLabels = series.points
+    .filter((_, i) => i % xStep === 0 || i === series.points.length - 1)
+    .map((p, _, arr) => {
+      const idx = series.points.indexOf(p)
+      return { date: p.date, x: scaleX(idx) }
+    })
+
+  function handleMouseMove(e: React.MouseEvent<SVGSVGElement>) {
+    const svg = e.currentTarget
+    const rect = svg.getBoundingClientRect()
+    const mouseX = ((e.clientX - rect.left) / rect.width) * width
+    const idx = Math.round(((mouseX - padding.left) / chartW) * (series.points.length - 1))
+    const clamped = Math.max(0, Math.min(series.points.length - 1, idx))
+    const point = series.points[clamped]!
+    setTooltip({ x: scaleX(clamped), y: scaleY(point.value), date: point.date, value: point.value })
+  }
+
+  const formatValue = (v: number) => v.toLocaleString('ru-RU', { maximumFractionDigits: 0 })
+  const formatDate = (d: string) => {
+    const parts = d.split('-')
+    return `${parts[2]}.${parts[1]}`
+  }
+
+  return (
+    <div className="chart-container">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="portfolio-chart"
+        onMouseMove={handleMouseMove}
+        onMouseLeave={() => setTooltip(null)}
+      >
+        {yLabels.map((tick, i) => (
+          <g key={i}>
+            <line x1={padding.left} y1={tick.y} x2={width - padding.right} y2={tick.y} stroke="#e0e0e0" strokeWidth="1" />
+            <text x={padding.left - 8} y={tick.y + 4} textAnchor="end" fontSize="11" fill="#999">
+              {formatValue(tick.value)}
+            </text>
+          </g>
+        ))}
+        {xLabels.map((tick, i) => (
+          <text key={i} x={tick.x} y={height - 8} textAnchor="middle" fontSize="11" fill="#999">
+            {formatDate(tick.date)}
+          </text>
+        ))}
+        <polygon points={gradientPoints} fill="#1976d2" opacity="0.1" />
+        <polyline points={polylinePoints} fill="none" stroke="#1976d2" strokeWidth="2" />
+        {tooltip && (
+          <>
+            <line x1={tooltip.x} y1={padding.top} x2={tooltip.x} y2={padding.top + chartH} stroke="#1976d2" strokeWidth="1" strokeDasharray="4" />
+            <circle cx={tooltip.x} cy={tooltip.y} r="4" fill="#1976d2" />
+            <rect x={tooltip.x - 60} y={tooltip.y - 38} width="120" height="30" rx="4" fill="#333" />
+            <text x={tooltip.x} y={tooltip.y - 24} textAnchor="middle" fontSize="10" fill="#fff">
+              {formatDate(tooltip.date)} — {formatValue(tooltip.value)} ₽
+            </text>
+          </>
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/ReportBuilder.tsx
+++ b/src/features/analytics/ui/ReportBuilder.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import type { ReportConfig, ReportPeriodType, GeneratedReport } from '../domain/models'
+import { getReportTitle } from '../services/report-service'
+import { exportToCsv, exportToHtml, downloadFile } from '../services/export-service'
+
+interface ReportBuilderProps {
+  onGenerate: (config: ReportConfig) => GeneratedReport | null
+}
+
+export function ReportBuilder({ onGenerate }: ReportBuilderProps) {
+  const currentYear = new Date().getFullYear()
+  const [periodType, setPeriodType] = useState<ReportPeriodType>('yearly')
+  const [year, setYear] = useState(currentYear)
+  const [month, setMonth] = useState(1)
+  const [quarter, setQuarter] = useState(1)
+  const [includeCharts, setIncludeCharts] = useState(true)
+  const [includeTax, setIncludeTax] = useState(true)
+  const [includeTransactions, setIncludeTransactions] = useState(true)
+  const [report, setReport] = useState<GeneratedReport | null>(null)
+
+  const config: ReportConfig = {
+    periodType,
+    year,
+    month: periodType === 'monthly' ? month : undefined,
+    quarter: periodType === 'quarterly' ? quarter : undefined,
+    includeCharts,
+    includeTaxBreakdown: includeTax,
+    includeTransactions,
+  }
+
+  function handleGenerate() {
+    const result = onGenerate(config)
+    setReport(result)
+  }
+
+  function handleExportCsv() {
+    if (!report) return
+    const csv = exportToCsv(report)
+    downloadFile(csv, `report-${year}.csv`, 'text/csv;charset=utf-8')
+  }
+
+  function handleExportHtml() {
+    if (!report) return
+    const html = exportToHtml(report)
+    const win = window.open()
+    if (win) {
+      win.document.write(html)
+      win.document.close()
+    }
+  }
+
+  const monthNames = [
+    'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
+    'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь',
+  ]
+
+  return (
+    <div className="report-builder-section">
+      <h4 className="report-builder-title">Генератор отчётов</h4>
+
+      <div className="report-config">
+        <div className="config-row">
+          <label className="config-label">Период</label>
+          <div className="config-buttons">
+            <button className={`config-btn ${periodType === 'monthly' ? 'active' : ''}`} onClick={() => setPeriodType('monthly')}>Месяц</button>
+            <button className={`config-btn ${periodType === 'quarterly' ? 'active' : ''}`} onClick={() => setPeriodType('quarterly')}>Квартал</button>
+            <button className={`config-btn ${periodType === 'yearly' ? 'active' : ''}`} onClick={() => setPeriodType('yearly')}>Год</button>
+          </div>
+        </div>
+
+        <div className="config-row">
+          <label className="config-label">Год</label>
+          <select className="config-select" value={year} onChange={e => setYear(Number(e.target.value))}>
+            {[currentYear, currentYear - 1, currentYear - 2].map(y => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
+
+        {periodType === 'monthly' && (
+          <div className="config-row">
+            <label className="config-label">Месяц</label>
+            <select className="config-select" value={month} onChange={e => setMonth(Number(e.target.value))}>
+              {monthNames.map((name, i) => (
+                <option key={i} value={i + 1}>{name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {periodType === 'quarterly' && (
+          <div className="config-row">
+            <label className="config-label">Квартал</label>
+            <select className="config-select" value={quarter} onChange={e => setQuarter(Number(e.target.value))}>
+              <option value={1}>I квартал</option>
+              <option value={2}>II квартал</option>
+              <option value={3}>III квартал</option>
+              <option value={4}>IV квартал</option>
+            </select>
+          </div>
+        )}
+
+        <div className="config-row config-checkboxes">
+          <label className="config-checkbox">
+            <input type="checkbox" checked={includeCharts} onChange={e => setIncludeCharts(e.target.checked)} />
+            Включить графики
+          </label>
+          <label className="config-checkbox">
+            <input type="checkbox" checked={includeTax} onChange={e => setIncludeTax(e.target.checked)} />
+            Налоговая сводка
+          </label>
+          <label className="config-checkbox">
+            <input type="checkbox" checked={includeTransactions} onChange={e => setIncludeTransactions(e.target.checked)} />
+            История операций
+          </label>
+        </div>
+
+        <button className="report-generate-btn" onClick={handleGenerate}>
+          Сгенерировать отчёт
+        </button>
+      </div>
+
+      {report && (
+        <div className="report-preview">
+          <div className="report-preview-header">
+            <h5>Отчёт: {getReportTitle(report.config)}</h5>
+            <div className="report-export-buttons">
+              <button className="export-btn" onClick={handleExportCsv}>Скачать CSV</button>
+              <button className="export-btn" onClick={handleExportHtml}>Печать / PDF</button>
+            </div>
+          </div>
+          <div className="report-preview-summary">
+            <div className="report-metric">
+              <span className="report-metric-label">Доходность</span>
+              <span className={`report-metric-value ${report.portfolioReturn >= 0 ? 'positive' : 'negative'}`}>
+                {report.portfolioReturn >= 0 ? '+' : ''}{report.portfolioReturn.toFixed(2)}%
+              </span>
+            </div>
+            <div className="report-metric">
+              <span className="report-metric-label">Волатильность</span>
+              <span className="report-metric-value">{report.metrics.volatility.toFixed(2)}%</span>
+            </div>
+            <div className="report-metric">
+              <span className="report-metric-label">Коэфф. Шарпа</span>
+              <span className="report-metric-value">{report.metrics.sharpeRatio.toFixed(2)}</span>
+            </div>
+            {report.taxSummary && (
+              <div className="report-metric">
+                <span className="report-metric-label">Налоги</span>
+                <span className="report-metric-value">{report.taxSummary.totalTaxLiability.toLocaleString('ru-RU')} ₽</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/analytics/ui/RiskMetricsPanel.tsx
+++ b/src/features/analytics/ui/RiskMetricsPanel.tsx
@@ -1,0 +1,51 @@
+import type { RiskMetrics } from '../domain/models'
+
+interface RiskMetricsPanelProps {
+  metrics: RiskMetrics
+}
+
+export function RiskMetricsPanel({ metrics }: RiskMetricsPanelProps) {
+  const formatDate = (d: string) => {
+    if (!d) return '—'
+    const parts = d.split('-')
+    return `${parts[2]}.${parts[1]}.${parts[0]}`
+  }
+
+  return (
+    <div className="risk-metrics-panel">
+      <h4 className="risk-metrics-title">Метрики риска</h4>
+      <div className="risk-cards">
+        <div className="risk-card">
+          <div className="risk-card-label">Волатильность</div>
+          <div className="risk-card-value">{metrics.volatility.toFixed(2)}%</div>
+          <div className="risk-card-desc">Годовая стандартное отклонение</div>
+        </div>
+        <div className="risk-card">
+          <div className="risk-card-label">Коэфф. Шарпа</div>
+          <div className={`risk-card-value ${metrics.sharpeRatio >= 1 ? 'positive' : metrics.sharpeRatio < 0 ? 'negative' : ''}`}>
+            {metrics.sharpeRatio.toFixed(2)}
+          </div>
+          <div className="risk-card-desc">
+            {metrics.sharpeRatio >= 1 ? 'Хорошо' : metrics.sharpeRatio >= 0 ? 'Удовлетворительно' : 'Плохо'}
+          </div>
+        </div>
+        <div className="risk-card">
+          <div className="risk-card-label">Макс. просадка</div>
+          <div className="risk-card-value negative">{metrics.maxDrawdown.toFixed(2)}%</div>
+          <div className="risk-card-desc">
+            {metrics.maxDrawdownPeriod.peakDate && metrics.maxDrawdownPeriod.troughDate
+              ? `${formatDate(metrics.maxDrawdownPeriod.peakDate)} — ${formatDate(metrics.maxDrawdownPeriod.troughDate)}`
+              : '—'}
+          </div>
+        </div>
+        {metrics.beta !== undefined && (
+          <div className="risk-card">
+            <div className="risk-card-label">Бета</div>
+            <div className="risk-card-value">{metrics.beta.toFixed(2)}</div>
+            <div className="risk-card-desc">Относительно IMOEX</div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/TaxSummary.tsx
+++ b/src/features/analytics/ui/TaxSummary.tsx
@@ -1,0 +1,75 @@
+import type { TaxReport } from '../domain/models'
+
+interface TaxSummaryProps {
+  report: TaxReport
+}
+
+export function TaxSummary({ report }: TaxSummaryProps) {
+  const formatAmount = (v: number) => v.toLocaleString('ru-RU', { maximumFractionDigits: 2 })
+  const formatDate = (d: string) => {
+    const parts = d.split('-')
+    return `${parts[2]}.${parts[1]}.${parts[0]}`
+  }
+
+  const periodLabel = report.period.quarter
+    ? `${['I', 'II', 'III', 'IV'][report.period.quarter - 1]} квартал ${report.period.year}`
+    : `${report.period.year} год`
+
+  return (
+    <div className="tax-summary-section">
+      <h4 className="tax-summary-title">Налоговая сводка — {periodLabel}</h4>
+
+      <div className="tax-cards">
+        <div className="tax-card">
+          <div className="tax-card-label">Дивиденды</div>
+          <div className="tax-card-value">{formatAmount(report.dividendIncome)} ₽</div>
+          <div className="tax-card-tax">Налог: {formatAmount(report.dividendTax)} ₽</div>
+        </div>
+        <div className="tax-card">
+          <div className="tax-card-label">Прирост капитала</div>
+          <div className="tax-card-value">{formatAmount(report.capitalGains)} ₽</div>
+          <div className="tax-card-tax">Налог: {formatAmount(report.capitalGainsTax)} ₽</div>
+        </div>
+        <div className="tax-card">
+          <div className="tax-card-label">Льготные доходы</div>
+          <div className="tax-card-value positive">{formatAmount(report.taxExemptGains)} ₽</div>
+          <div className="tax-card-tax">Освобождено от налога</div>
+        </div>
+        <div className="tax-card tax-card-total">
+          <div className="tax-card-label">Итого к уплате</div>
+          <div className="tax-card-value">{formatAmount(report.totalTaxLiability)} ₽</div>
+        </div>
+      </div>
+
+      {report.transactions.length > 0 && (
+        <div className="tax-transactions">
+          <h5>Налогооблагаемые операции</h5>
+          <table className="tax-table">
+            <thead>
+              <tr>
+                <th>Дата</th>
+                <th>Тикер</th>
+                <th>Тип</th>
+                <th>Сумма</th>
+                <th>Налог</th>
+                <th>Льгота</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.transactions.map((tx, i) => (
+                <tr key={i}>
+                  <td>{formatDate(tx.date)}</td>
+                  <td className="tx-ticker">{tx.ticker}</td>
+                  <td>{tx.type === 'dividend' ? 'Дивиденды' : 'Продажа'}</td>
+                  <td>{formatAmount(tx.amount)} ₽</td>
+                  <td>{formatAmount(tx.taxAmount)} ₽</td>
+                  <td>{tx.isExempt ? <span className="tax-exempt-badge">{tx.exemptReason}</span> : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/analytics/ui/TransactionHistory.tsx
+++ b/src/features/analytics/ui/TransactionHistory.tsx
@@ -1,0 +1,81 @@
+import type { TaxableTransaction } from '../domain/models'
+import { useState } from 'react'
+
+interface TransactionHistoryProps {
+  transactions: TaxableTransaction[]
+}
+
+type FilterType = 'all' | 'dividend' | 'sale'
+
+export function TransactionHistory({ transactions }: TransactionHistoryProps) {
+  const [filter, setFilter] = useState<FilterType>('all')
+
+  const filtered = filter === 'all'
+    ? transactions
+    : transactions.filter(t => t.type === filter)
+
+  const sorted = [...filtered].sort((a, b) => b.date.localeCompare(a.date))
+
+  const formatDate = (d: string) => {
+    const parts = d.split('-')
+    return `${parts[2]}.${parts[1]}.${parts[0]}`
+  }
+
+  const formatAmount = (v: number) => v.toLocaleString('ru-RU', { maximumFractionDigits: 2 })
+
+  const totalAmount = sorted.reduce((s, t) => s + t.amount, 0)
+  const totalTax = sorted.reduce((s, t) => s + t.taxAmount, 0)
+
+  return (
+    <div className="transaction-history-section">
+      <div className="transaction-header">
+        <h4 className="transaction-title">История операций</h4>
+        <div className="transaction-filters">
+          <button className={`filter-btn ${filter === 'all' ? 'active' : ''}`} onClick={() => setFilter('all')}>Все</button>
+          <button className={`filter-btn ${filter === 'dividend' ? 'active' : ''}`} onClick={() => setFilter('dividend')}>Дивиденды</button>
+          <button className={`filter-btn ${filter === 'sale' ? 'active' : ''}`} onClick={() => setFilter('sale')}>Продажи</button>
+        </div>
+      </div>
+
+      <div className="transaction-summary">
+        <span>Операций: {sorted.length}</span>
+        <span>Сумма: {formatAmount(totalAmount)} ₽</span>
+        <span>Налоги: {formatAmount(totalTax)} ₽</span>
+      </div>
+
+      <table className="transaction-table">
+        <thead>
+          <tr>
+            <th>Дата</th>
+            <th>Тикер</th>
+            <th>Тип</th>
+            <th>Сумма</th>
+            <th>Налог</th>
+            <th>Статус</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((tx, i) => (
+            <tr key={i}>
+              <td>{formatDate(tx.date)}</td>
+              <td className="tx-ticker">{tx.ticker}</td>
+              <td>
+                <span className={`tx-type-badge ${tx.type}`}>
+                  {tx.type === 'dividend' ? 'Дивиденды' : 'Продажа'}
+                </span>
+              </td>
+              <td>{formatAmount(tx.amount)} ₽</td>
+              <td>{formatAmount(tx.taxAmount)} ₽</td>
+              <td>
+                {tx.isExempt
+                  ? <span className="tax-exempt-badge">{tx.exemptReason}</span>
+                  : <span className="tax-paid-badge">Облагается</span>
+                }
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/features/analytics/ui/__tests__/AnalyticsPage.test.tsx
+++ b/src/features/analytics/ui/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AnalyticsPage } from '../AnalyticsPage'
+
+describe('AnalyticsPage', () => {
+  it('renders page title', () => {
+    render(<AnalyticsPage />)
+    expect(screen.getByText('Аналитика')).toBeTruthy()
+  })
+
+  it('renders tab navigation', () => {
+    render(<AnalyticsPage />)
+    expect(screen.getByText('Обзор')).toBeTruthy()
+    expect(screen.getByText('Графики')).toBeTruthy()
+    expect(screen.getByText('Метрики')).toBeTruthy()
+    expect(screen.getByText('Отчёты')).toBeTruthy()
+    expect(screen.getByText('Налоги')).toBeTruthy()
+  })
+
+  it('renders period selector', () => {
+    render(<AnalyticsPage />)
+    expect(screen.getByText('1М')).toBeTruthy()
+    expect(screen.getByText('3М')).toBeTruthy()
+    expect(screen.getByText('1Г')).toBeTruthy()
+    expect(screen.getByText('Всё')).toBeTruthy()
+  })
+
+  it('renders overview cards by default', () => {
+    render(<AnalyticsPage />)
+    expect(screen.getByText('Стоимость портфеля')).toBeTruthy()
+    expect(screen.getByText('Доходность')).toBeTruthy()
+    expect(screen.getByText('Волатильность')).toBeTruthy()
+    expect(screen.getByText('Коэфф. Шарпа')).toBeTruthy()
+  })
+
+  it('switches to charts tab', () => {
+    render(<AnalyticsPage />)
+    fireEvent.click(screen.getByText('Графики'))
+    expect(screen.getByText('Стоимость портфеля')).toBeTruthy()
+    expect(screen.getByText('Сравнение с бенчмарком')).toBeTruthy()
+  })
+
+  it('switches to metrics tab', () => {
+    render(<AnalyticsPage />)
+    fireEvent.click(screen.getByText('Метрики'))
+    expect(screen.getByText('Метрики риска')).toBeTruthy()
+  })
+
+  it('switches to reports tab', () => {
+    render(<AnalyticsPage />)
+    fireEvent.click(screen.getByText('Отчёты'))
+    expect(screen.getByText('Генератор отчётов')).toBeTruthy()
+  })
+
+  it('switches to tax tab', () => {
+    render(<AnalyticsPage />)
+    fireEvent.click(screen.getByText('Налоги'))
+    expect(screen.getByText('Налоговая сводка — 2025 год')).toBeTruthy()
+    expect(screen.getByText('История операций')).toBeTruthy()
+  })
+})

--- a/src/features/analytics/ui/__tests__/ReportBuilder.test.tsx
+++ b/src/features/analytics/ui/__tests__/ReportBuilder.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ReportBuilder } from '../ReportBuilder'
+import type { GeneratedReport, RiskMetrics } from '../../domain/models'
+
+describe('ReportBuilder', () => {
+  const mockMetrics: RiskMetrics = {
+    volatility: 15, sharpeRatio: 0.8, maxDrawdown: 10,
+    maxDrawdownPeriod: { peakDate: '2025-01-01', troughDate: '2025-02-01' },
+  }
+
+  const mockReport: GeneratedReport = {
+    config: { periodType: 'yearly', year: 2025, includeCharts: true, includeTaxBreakdown: true, includeTransactions: true },
+    generatedAt: new Date().toISOString(),
+    metrics: mockMetrics,
+    allocation: [{ category: 'Акции', value: 100000, percent: 70, color: '#1976d2' }],
+    portfolioReturn: 12.5,
+  }
+
+  it('renders title', () => {
+    render(<ReportBuilder onGenerate={() => null} />)
+    expect(screen.getByText('Генератор отчётов')).toBeTruthy()
+  })
+
+  it('renders period type buttons', () => {
+    render(<ReportBuilder onGenerate={() => null} />)
+    expect(screen.getByText('Месяц')).toBeTruthy()
+    expect(screen.getByText('Квартал')).toBeTruthy()
+    expect(screen.getByText('Год')).toBeTruthy()
+  })
+
+  it('renders generate button', () => {
+    render(<ReportBuilder onGenerate={() => null} />)
+    expect(screen.getByText('Сгенерировать отчёт')).toBeTruthy()
+  })
+
+  it('calls onGenerate when button clicked', () => {
+    const onGenerate = vi.fn().mockReturnValue(mockReport)
+    render(<ReportBuilder onGenerate={onGenerate} />)
+    fireEvent.click(screen.getByText('Сгенерировать отчёт'))
+    expect(onGenerate).toHaveBeenCalled()
+  })
+
+  it('shows report preview after generation', () => {
+    const onGenerate = vi.fn().mockReturnValue(mockReport)
+    render(<ReportBuilder onGenerate={onGenerate} />)
+    fireEvent.click(screen.getByText('Сгенерировать отчёт'))
+    expect(screen.getByText('Скачать CSV')).toBeTruthy()
+    expect(screen.getByText('Печать / PDF')).toBeTruthy()
+  })
+
+  it('shows month selector for monthly period', () => {
+    render(<ReportBuilder onGenerate={() => null} />)
+    fireEvent.click(screen.getByText('Месяц'))
+    expect(screen.getByText('Январь')).toBeTruthy()
+  })
+
+  it('shows quarter selector for quarterly period', () => {
+    render(<ReportBuilder onGenerate={() => null} />)
+    fireEvent.click(screen.getByText('Квартал'))
+    expect(screen.getByText('I квартал')).toBeTruthy()
+  })
+})

--- a/src/features/analytics/ui/__tests__/RiskMetricsPanel.test.tsx
+++ b/src/features/analytics/ui/__tests__/RiskMetricsPanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RiskMetricsPanel } from '../RiskMetricsPanel'
+import type { RiskMetrics } from '../../domain/models'
+
+describe('RiskMetricsPanel', () => {
+  const mockMetrics: RiskMetrics = {
+    volatility: 18.5,
+    sharpeRatio: 1.2,
+    maxDrawdown: 12.3,
+    maxDrawdownPeriod: {
+      peakDate: '2025-03-15',
+      troughDate: '2025-04-10',
+    },
+  }
+
+  it('renders volatility', () => {
+    render(<RiskMetricsPanel metrics={mockMetrics} />)
+    expect(screen.getByText('Волатильность')).toBeTruthy()
+    expect(screen.getByText('18.50%')).toBeTruthy()
+  })
+
+  it('renders Sharpe ratio', () => {
+    render(<RiskMetricsPanel metrics={mockMetrics} />)
+    expect(screen.getByText('Коэфф. Шарпа')).toBeTruthy()
+    expect(screen.getByText('1.20')).toBeTruthy()
+  })
+
+  it('renders max drawdown with dates', () => {
+    render(<RiskMetricsPanel metrics={mockMetrics} />)
+    expect(screen.getByText('Макс. просадка')).toBeTruthy()
+    expect(screen.getByText('12.30%')).toBeTruthy()
+    expect(screen.getByText('15.03.2025 — 10.04.2025')).toBeTruthy()
+  })
+
+  it('shows quality rating for good Sharpe', () => {
+    render(<RiskMetricsPanel metrics={mockMetrics} />)
+    expect(screen.getByText('Хорошо')).toBeTruthy()
+  })
+
+  it('shows beta when provided', () => {
+    const withBeta = { ...mockMetrics, beta: 0.85 }
+    render(<RiskMetricsPanel metrics={withBeta} />)
+    expect(screen.getByText('Бета')).toBeTruthy()
+    expect(screen.getByText('0.85')).toBeTruthy()
+  })
+})

--- a/src/features/analytics/ui/__tests__/TaxSummary.test.tsx
+++ b/src/features/analytics/ui/__tests__/TaxSummary.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TaxSummary } from '../TaxSummary'
+import type { TaxReport } from '../../domain/models'
+
+describe('TaxSummary', () => {
+  const mockReport: TaxReport = {
+    period: { year: 2025 },
+    dividendIncome: 30000,
+    dividendTax: 3900,
+    capitalGains: 10000,
+    capitalGainsTax: 1300,
+    taxExemptGains: 5000,
+    totalTaxLiability: 5200,
+    transactions: [
+      { date: '2025-03-15', ticker: 'SBER', type: 'dividend', amount: 18500, taxAmount: 2405, isExempt: false },
+      { date: '2025-05-22', ticker: 'MOEX', type: 'sale', amount: 2800, taxAmount: 0, isExempt: true, exemptReason: '3+ года владения' },
+    ],
+  }
+
+  it('renders period title', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('Налоговая сводка — 2025 год')).toBeTruthy()
+  })
+
+  it('renders dividend income card', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('Дивиденды')).toBeTruthy()
+  })
+
+  it('renders capital gains card', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('Прирост капитала')).toBeTruthy()
+  })
+
+  it('renders total tax liability', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('Итого к уплате')).toBeTruthy()
+  })
+
+  it('renders transactions table', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('Налогооблагаемые операции')).toBeTruthy()
+    expect(screen.getByText('SBER')).toBeTruthy()
+    expect(screen.getByText('MOEX')).toBeTruthy()
+  })
+
+  it('shows exempt badge', () => {
+    render(<TaxSummary report={mockReport} />)
+    expect(screen.getByText('3+ года владения')).toBeTruthy()
+  })
+
+  it('renders quarterly period', () => {
+    const q2Report = { ...mockReport, period: { year: 2025, quarter: 2 } }
+    render(<TaxSummary report={q2Report} />)
+    expect(screen.getByText('Налоговая сводка — II квартал 2025')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Implements Issue #4: Analytics and Reports system for the investment portfolio application.

### Architecture
- **4 computation engines** (pure functions): time-series, risk-metrics, benchmark, tax
- **3 services**: analytics orchestrator, report generator, export (CSV/HTML/print)
- **11 UI components**: AnalyticsPage (5 tabs), charts (SVG line, conic-gradient pie, CSS bars, grid heatmap), report builder with export
- **11 test files** covering all engines, services, and UI components

### Features
- Portfolio value over time (SVG line chart with tooltip)
- Asset allocation by type, sector, geography (pie charts, bar charts)
- Risk metrics: volatility, Sharpe ratio, max drawdown
- Benchmark comparison vs IMOEX (dual-line chart with alpha)
- Correlation matrix (CSS grid heatmap)
- Tax reporting: dividends, capital gains, 3-year exemption (NDFL 13%/15%)
- Report builder: monthly/quarterly/yearly with CSV export and print/PDF
- Transaction history with filters
- Period selector (1M/3M/6M/1Y/YTD/ALL)

### Technical Details
- 35 files changed, 3400 lines added
- Reuses NDFL constants from portfolio-optimization
- All charts CSS-only (SVG + conic-gradient, no external libraries)
- Russian localization throughout
- Mock data with realistic portfolio snapshots

Closes #4